### PR TITLE
fix(install): detect Windows/MINGW64 and download prebuilt binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A high-performance hook for AI coding agents that blocks destructive commands be
 curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/destructive_command_guard/master/install.sh?$(date +%s)" | bash -s -- --easy-mode
 ```
 
-<p><em>Works on Linux, macOS, and Windows (WSL). Auto-detects your platform and downloads the right binary.</em></p>
+<p><em>Works on Linux, macOS, and Windows (WSL, Git Bash, MSYS2). Auto-detects your platform and downloads the right binary.</em></p>
 </div>
 
 ---


### PR DESCRIPTION
On Git Bash (MINGW64), uname -s returns "MINGW64_NT-*" which wasn't recognized as Windows, causing unnecessary build-from-source fallback.

Changes:
- Detect MINGW64/MSYS2/Cygwin environments as Windows
- Map to x86_64-pc-windows-msvc target for prebuilt binary download
- Use .zip format and unzip for Windows artifacts
- Install dcg.exe with a shell wrapper so 'dcg' works in Git Bash
- Update README to mention Git Bash/MSYS2 support