### PR TITLE
Add Augment Code CLI (auggie) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 A high-performance hook for AI coding agents that blocks destructive commands before they execute, protecting your work from accidental deletion.
 
-**Supported:** [Claude Code](https://claude.ai/code), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Aider](https://aider.chat/) (limited—git hooks only), [Continue](https://continue.dev) (detection only), [Codex CLI](https://github.com/openai/codex) (detection only)
+**Supported:** [Claude Code](https://claude.ai/code), [Augment Code CLI (`auggie`)](https://www.augmentcode.com/), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Aider](https://aider.chat/) (limited—git hooks only), [Continue](https://continue.dev) (detection only), [Codex CLI](https://github.com/openai/codex) (detection only)
 
 <div align="center">
 <h3>Quick Install</h3>
@@ -813,6 +813,25 @@ Add to `~/.claude/settings.json`:
 ```
 
 **Important:** Restart Claude Code after adding the hook configuration.
+
+## Augment Code CLI (`auggie`) Configuration
+
+Add to `~/.augment/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "launch-process",
+      "hooks": [{"type": "command", "command": "dcg"}]
+    }]
+  }
+}
+```
+
+**Important:** Restart the `auggie` CLI after adding the hook configuration.
+
+**Note:** This integration is for the Augment Code CLI (`auggie`) only. The interactive Augment Code IDE extension does not have hook support.
 
 ## Gemini CLI Configuration
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -9,6 +9,7 @@ trust to well-behaved agents while maintaining strict controls for unknown ones.
 | Agent | Detection Method | Environment Variable |
 |-------|------------------|---------------------|
 | Claude Code | Environment | `CLAUDE_CODE=1` or `CLAUDE_SESSION_ID` |
+| Augment Code CLI (`auggie`) | Environment | `AUGMENT_AGENT=1` or `AUGMENT_CONVERSATION_ID` |
 | Aider | Environment | `AIDER_SESSION=1` |
 | Continue | Environment | `CONTINUE_SESSION_ID` |
 | Codex CLI | Environment | `CODEX_CLI=1` |

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,8 +314,9 @@ fn main() {
             .map_or(HOOK_EVALUATION_BUDGET, Duration::from_millis),
     );
 
-    // Only process Bash tool invocations
-    if hook_input.tool_name.as_deref() != Some("Bash") {
+    // Only process Bash (Claude Code) or launch-process (Augment Code) tool invocations
+    let tool_name = hook_input.tool_name.as_deref();
+    if tool_name != Some("Bash") && tool_name != Some("launch-process") {
         return;
     }
 


### PR DESCRIPTION
This PR adds support for Augment Code CLI (auggie) to dcg.

## What this does

DCG now accepts both `Bash` (Claude Code) and `launch-process` (Augment Code CLI) tool names in hook input. This lets auggie users protect their work from destructive commands the same way Claude Code users can.

## Changes

**Core logic:**
- `src/hook.rs`: Updated `extract_command()` to accept both tool names
- `src/main.rs`: Updated the tool name check before evaluation

**Agent detection:**
- `src/agent.rs`: Added `AugmentCode` variant with environment detection via `AUGMENT_AGENT` or `AUGMENT_CONVERSATION_ID`

**Documentation:**
- `README.md`: Added configuration section for auggie
- `docs/agents.md`: Added table entry

## Configuration

Users add this to `~/.augment/settings.json`:

```json
{
  "hooks": {
    "PreToolUse": [{
      "matcher": "launch-process",
      "hooks": [{"type": "command", "command": "dcg"}]
    }]
  }
}
```

## Testing

- All existing tests pass
- Added 3 new tests for Augment-specific functionality
- Verified end-to-end with `auggie --print "run: git reset --hard"` (correctly blocked)

## Scope note

This is for the Augment Code CLI (`auggie`) only. The interactive Augment Code IDE extension has its own safeguards and doesn't use the same hook system.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author