### PR TITLE
Add GitHub Copilot as a supported agent

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -13,6 +13,7 @@ trust to well-behaved agents while maintaining strict controls for unknown ones.
 | Continue | Environment | `CONTINUE_SESSION_ID` |
 | Codex CLI | Environment | `CODEX_CLI=1` |
 | Gemini CLI | Environment | `GEMINI_CLI=1` |
+| GitHub Copilot CLI | Environment | `COPILOT_CLI=1`, `TERM_PROGRAM=vscode`, or `COPILOT_AGENT_START_TIME_SEC` |
 
 ## Detection Priority
 
@@ -42,6 +43,10 @@ Configure agent profiles in your `config.toml`:
 [agents.claude-code]
 trust_level = "high"
 additional_allowlist = ["npm run build", "cargo test"]
+
+[agents.copilot]
+trust_level = "medium"
+additional_allowlist = ["npm test"]
 
 # Restrict unknown agents
 [agents.unknown]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -17,6 +17,7 @@
 //! - Continue: `CONTINUE_SESSION_ID` env var
 //! - Codex CLI: `CODEX_CLI=1` env var
 //! - Gemini CLI: `GEMINI_CLI=1` env var
+//! - GitHub Copilot CLI: `COPILOT_CLI=1`, `TERM_PROGRAM=vscode`, or `COPILOT_AGENT_START_TIME_SEC` env var
 //!
 //! # Usage
 //!
@@ -53,6 +54,8 @@ pub enum Agent {
     CodexCli,
     /// Google Gemini CLI.
     GeminiCli,
+    /// GitHub Copilot CLI.
+    CopilotCli,
     /// A custom agent specified by name.
     Custom(String),
     /// Unknown or undetected agent.
@@ -73,6 +76,7 @@ impl Agent {
             Self::Continue => "continue",
             Self::CodexCli => "codex-cli",
             Self::GeminiCli => "gemini-cli",
+            Self::CopilotCli => "copilot-cli",
             Self::Custom(name) => name,
             Self::Unknown => "unknown",
         }
@@ -89,6 +93,7 @@ impl Agent {
                 | Self::Continue
                 | Self::CodexCli
                 | Self::GeminiCli
+                | Self::CopilotCli
         )
     }
 
@@ -107,6 +112,7 @@ impl Agent {
     /// - `"continue"` -> `Continue`
     /// - `"codex"`, `"codex-cli"`, `"codex_cli"` -> `CodexCli`
     /// - `"gemini"`, `"gemini-cli"`, `"gemini_cli"` -> `GeminiCli`
+    /// - `"copilot"`, `"copilot-cli"`, `"copilot_cli"`, -> `CopilotCli`
     /// - `"unknown"` -> `Unknown`
     /// - Any other value -> `Custom(value)`
     #[must_use]
@@ -119,6 +125,7 @@ impl Agent {
             "continue" => Self::Continue,
             "codexcli" | "codex" => Self::CodexCli,
             "geminicli" | "gemini" => Self::GeminiCli,
+            "copilotcli" | "copilot" => Self::CopilotCli,
             "unknown" => Self::Unknown,
             _ => Self::Custom(name.to_string()),
         }
@@ -134,6 +141,7 @@ impl fmt::Display for Agent {
             Self::Continue => write!(f, "Continue"),
             Self::CodexCli => write!(f, "Codex CLI"),
             Self::GeminiCli => write!(f, "Gemini CLI"),
+            Self::CopilotCli => write!(f, "GitHub Copilot CLI"),
             Self::Custom(name) => write!(f, "{name}"),
             Self::Unknown => write!(f, "Unknown"),
         }
@@ -363,6 +371,29 @@ fn detect_from_environment() -> Option<DetectionResult> {
         ));
     }
 
+    // GitHub Copilot CLI detection
+    if matches!(std::env::var("COPILOT_CLI").as_deref(), Ok("1")) {
+        return Some(DetectionResult::new(
+            Agent::CopilotCli,
+            DetectionMethod::Environment,
+            Some("COPILOT_CLI".to_string()),
+        ));
+    }
+    if matches!(std::env::var("TERM_PROGRAM").as_deref(), Ok("vscode")) {
+        return Some(DetectionResult::new(
+            Agent::CopilotCli,
+            DetectionMethod::Environment,
+            Some("TERM_PROGRAM".to_string()),
+        ));
+    }
+    if std::env::var_os("COPILOT_AGENT_START_TIME_SEC").is_some() {
+        return Some(DetectionResult::new(
+            Agent::CopilotCli,
+            DetectionMethod::Environment,
+            Some("COPILOT_AGENT_START_TIME_SEC".to_string()),
+        ));
+    }
+
     None
 }
 
@@ -458,6 +489,7 @@ mod tests {
         assert_eq!(Agent::Continue.config_key(), "continue");
         assert_eq!(Agent::CodexCli.config_key(), "codex-cli");
         assert_eq!(Agent::GeminiCli.config_key(), "gemini-cli");
+        assert_eq!(Agent::CopilotCli.config_key(), "copilot-cli");
         assert_eq!(Agent::Unknown.config_key(), "unknown");
         assert_eq!(
             Agent::Custom("my-agent".to_string()).config_key(),
@@ -474,6 +506,7 @@ mod tests {
         assert_eq!(Agent::from_name("continue"), Agent::Continue);
         assert_eq!(Agent::from_name("codex-cli"), Agent::CodexCli);
         assert_eq!(Agent::from_name("gemini-cli"), Agent::GeminiCli);
+        assert_eq!(Agent::from_name("copilot-cli"), Agent::CopilotCli);
         assert_eq!(Agent::from_name("unknown"), Agent::Unknown);
 
         // Variations
@@ -485,6 +518,7 @@ mod tests {
         assert_eq!(Agent::from_name("augment"), Agent::AugmentCode);
         assert_eq!(Agent::from_name("codex"), Agent::CodexCli);
         assert_eq!(Agent::from_name("gemini"), Agent::GeminiCli);
+        assert_eq!(Agent::from_name("copilot"), Agent::CopilotCli);
 
         // Custom agents
         assert_eq!(
@@ -501,6 +535,7 @@ mod tests {
         assert_eq!(format!("{}", Agent::Continue), "Continue");
         assert_eq!(format!("{}", Agent::CodexCli), "Codex CLI");
         assert_eq!(format!("{}", Agent::GeminiCli), "Gemini CLI");
+        assert_eq!(format!("{}", Agent::CopilotCli), "GitHub Copilot CLI");
         assert_eq!(format!("{}", Agent::Unknown), "Unknown");
         assert_eq!(
             format!("{}", Agent::Custom("MyAgent".to_string())),
@@ -513,6 +548,7 @@ mod tests {
         assert!(Agent::ClaudeCode.is_known());
         assert!(Agent::AugmentCode.is_known());
         assert!(Agent::Aider.is_known());
+        assert!(Agent::CopilotCli.is_known());
         assert!(!Agent::Unknown.is_known());
         assert!(!Agent::Custom("x".to_string()).is_known());
     }
@@ -567,6 +603,9 @@ mod env_tests {
         "CONTINUE_SESSION_ID",
         "CODEX_CLI",
         "GEMINI_CLI",
+        "COPILOT_CLI",
+        "TERM_PROGRAM",
+        "COPILOT_AGENT_START_TIME_SEC",
     ];
 
     fn with_env_var<F, R>(key: &str, value: &str, f: F) -> R
@@ -694,6 +733,55 @@ mod env_tests {
     }
 
     #[test]
+    fn test_detect_copilot_cli_env() {
+        with_env_var("COPILOT_CLI", "1", || {
+            let result = detect_agent_with_details();
+            assert_eq!(result.agent, Agent::CopilotCli);
+            assert_eq!(result.method, DetectionMethod::Environment);
+            assert_eq!(result.matched_value, Some("COPILOT_CLI".to_string()));
+        });
+    }
+
+    #[test]
+    fn test_detect_copilot_in_vscode_env() {
+        with_env_var("TERM_PROGRAM", "vscode", || {
+            let result = detect_agent_with_details();
+            assert_eq!(result.agent, Agent::CopilotCli);
+            assert_eq!(result.method, DetectionMethod::Environment);
+            assert_eq!(result.matched_value, Some("TERM_PROGRAM".to_string()));
+        });
+    }
+
+    #[test]
+    fn test_detect_copilot_in_github_actions_env() {
+        with_env_var("COPILOT_AGENT_START_TIME_SEC", "", || {
+            let result = detect_agent_with_details();
+            assert_eq!(result.agent, Agent::CopilotCli);
+            assert_eq!(result.method, DetectionMethod::Environment);
+            assert_eq!(
+                result.matched_value,
+                Some("COPILOT_AGENT_START_TIME_SEC".to_string())
+            );
+        });
+    }
+
+    #[test]
+    fn test_ignore_copilot_cli_when_not_one() {
+        with_env_var("COPILOT_CLI", "0", || {
+            let result = detect_agent_with_details();
+            assert_ne!(result.agent, Agent::CopilotCli);
+        });
+    }
+
+    #[test]
+    fn test_ignore_term_program_when_not_vscode() {
+        with_env_var("TERM_PROGRAM", "xterm-256color", || {
+            let result = detect_agent_with_details();
+            assert_ne!(result.agent, Agent::CopilotCli);
+        });
+    }
+
+    #[test]
     fn test_detect_unknown_no_env() {
         // Acquire lock to prevent race conditions with parallel tests
         let _lock = ENV_LOCK.lock().unwrap();
@@ -709,6 +797,7 @@ mod env_tests {
             std::env::remove_var("CONTINUE_SESSION_ID");
             std::env::remove_var("CODEX_CLI");
             std::env::remove_var("GEMINI_CLI");
+            std::env::remove_var("COPILOT_CLI");
         }
 
         // Detection should fall back to process detection or Unknown

--- a/tests/agent_profile_comprehensive.rs
+++ b/tests/agent_profile_comprehensive.rs
@@ -99,6 +99,7 @@ fn run_test_command_as_agent(command: &str, agent: &str) -> (String, String, i32
         "continue" => "CONTINUE_SESSION_ID",
         "codex" | "codex-cli" => "CODEX_CLI",
         "gemini" | "gemini-cli" => "GEMINI_CLI",
+        "copilot" | "copilot-cli" => "COPILOT_CLI",
         _ => "DCG_AGENT_TYPE",
     };
 
@@ -167,6 +168,18 @@ mod agent_detection_tests {
     fn test_detects_gemini_via_env() {
         let (_stdout, stderr, exit_code) =
             run_robot_mode_with_env(&["--version"], &[("GEMINI_CLI", "1")]);
+
+        assert_eq!(exit_code, 0, "version command should succeed");
+        assert!(
+            stderr.contains("dcg") || !stderr.is_empty(),
+            "should produce output on stderr"
+        );
+    }
+
+    #[test]
+    fn test_detects_copilot_via_env() {
+        let (_stdout, stderr, exit_code) =
+            run_robot_mode_with_env(&["--version"], &[("COPILOT_CLI", "1")]);
 
         assert_eq!(exit_code, 0, "version command should succeed");
         assert!(
@@ -270,6 +283,7 @@ mod trust_level_tests {
             ("AIDER_SESSION", "1"),
             ("CODEX_CLI", "1"),
             ("GEMINI_CLI", "1"),
+            ("COPILOT_CLI", "1"),
         ];
 
         for cmd in destructive_commands {
@@ -320,6 +334,7 @@ mod trust_level_tests {
             ("AIDER_SESSION", "1"),
             ("CODEX_CLI", "1"),
             ("GEMINI_CLI", "1"),
+            ("COPILOT_CLI", "1"),
         ];
 
         for cmd in safe_commands {
@@ -378,6 +393,7 @@ mod agent_allowlist_tests {
             ("CLAUDE_CODE", "1"),
             ("AIDER_SESSION", "1"),
             ("CODEX_CLI", "1"),
+            ("COPILOT_CLI", "1"),
         ];
 
         let mut results: HashMap<&str, bool> = HashMap::new();


### PR DESCRIPTION
Hey, so I didn't notice your "contribution policy" until I had already done this.  I'm not bothered if you don't merge it, but I figured I would make it available in case any other Copilot users might need it.  GPT-5.3-Codex did most of it anyway, and the changes are all pretty trivial.

One notable point: Copilot doesn't actually provide any way to detect when it's running under VS Code that I could find, so I opted to check `TERM_PROGRAM=vscode`.  This *will* return a false positive if dcg is run from a regular VS Code terminal session.  Feel free to remove it if that's too hacky for you!
<hr />
This pull request adds full support for detecting and configuring the GitHub Copilot CLI as a recognized agent in the system. The changes include environment-based detection, updates to agent enums and configuration, documentation improvements, and comprehensive tests for Copilot CLI detection and trust-level handling.

**Agent detection and configuration:**

* Added `CopilotCli` variant to the `Agent` enum and updated related methods to support string conversions, display formatting, and config key usage. (`src/agent.rs`) [[1]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R57-R58) [[2]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R79) [[3]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R115) [[4]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R128) [[5]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R144)
* Implemented environment variable-based detection for GitHub Copilot CLI using `COPILOT_CLI=1`, `TERM_PROGRAM=vscode`, and `COPILOT_AGENT_START_TIME_SEC`. (`src/agent.rs`)

**Documentation updates:**

* Updated `docs/agents.md` to document Copilot CLI detection and provide configuration examples for agent profiles and allowlists. [[1]](diffhunk://#diff-a384388adcb2ed2bfeb1762af9c9b8b6f59402e1a6c94a7c459f120642085e64R16) [[2]](diffhunk://#diff-a384388adcb2ed2bfeb1762af9c9b8b6f59402e1a6c94a7c459f120642085e64R47-R50)
* Updated inline documentation in `src/agent.rs` to include Copilot CLI detection details.

**Test coverage improvements:**

* Added unit and integration tests for Copilot CLI detection via environment variables, string conversion, display formatting, and trust-level handling. (`src/agent.rs`, `tests/agent_profile_comprehensive.rs`) [[1]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R492) [[2]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R509) [[3]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R521) [[4]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R538) [[5]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R551) [[6]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R606-R608) [[7]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R735-R783) [[8]](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R800) [[9]](diffhunk://#diff-d0ddd1ea61ee1ae3ac336fbe266d88f076db35b684c54c786a3959d55808c7fcR102) [[10]](diffhunk://#diff-d0ddd1ea61ee1ae3ac336fbe266d88f076db35b684c54c786a3959d55808c7fcR179-R190) [[11]](diffhunk://#diff-d0ddd1ea61ee1ae3ac336fbe266d88f076db35b684c54c786a3959d55808c7fcR286) [[12]](diffhunk://#diff-d0ddd1ea61ee1ae3ac336fbe266d88f076db35b684c54c786a3959d55808c7fcR337) [[13]](diffhunk://#diff-d0ddd1ea61ee1ae3ac336fbe266d88f076db35b684c54c786a3959d55808c7fcR396)

These changes ensure Copilot CLI is treated as a first-class agent, with clear detection logic, configuration options, and robust test coverage.