### PR TITLE
fix(podman): catch combined flags like -af in rm/rmi patterns

### DIFF
--- a/src/packs/containers/podman.rs
+++ b/src/packs/containers/podman.rs
@@ -131,7 +131,7 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // rm -f (force remove containers)
         destructive_pattern!(
             "rm-force",
-            r"podman\s+rm\s+.*-f|podman\s+rm\s+.*--force",
+            r"podman\s+rm\s+(-\w*f\w*|--force)|podman\s+rm\s+.*\s+(-\w*f\w*|--force)",
             "podman rm -f forcibly removes containers, potentially losing data.",
             High,
             "podman rm -f forcibly stops and removes containers. This is dangerous because:\n\n\
@@ -147,7 +147,7 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // rmi -f (force remove images)
         destructive_pattern!(
             "rmi-force",
-            r"podman\s+rmi\s+.*-f|podman\s+rmi\s+.*--force",
+            r"podman\s+rmi\s+(-\w*f\w*|--force)|podman\s+rmi\s+.*\s+(-\w*f\w*|--force)",
             "podman rmi -f forcibly removes images even if in use.",
             High,
             "podman rmi -f forcibly removes images, even if containers reference them. \


### PR DESCRIPTION
## Summary
- Fix podman pack's `rm-force` and `rmi-force` patterns to catch combined flags like `-af`
- `podman rm -af` (remove all containers, force) was not being blocked because the regex `podman\s+rm\s+.*-f` didn't match when `-a` and `-f` are combined as `-af`

## Problem
`podman rm -af` kills **all** containers on the system. This is one of the most destructive podman commands but it was passing through DCG undetected.

The existing regex required something between `rm` and `-f`, but combined flags like `-af` put them adjacent.

## Fix
Updated regexes from:
```
podman\s+rm\s+.*-f|podman\s+rm\s+.*--force
```
to:
```
podman\s+rm\s+(-\w*f\w*|--force)|podman\s+rm\s+.*\s+(-\w*f\w*|--force)
```

This matches the pattern already used in the Docker pack (`(?:-[a-zA-Z0-9]*f|--force)`).

## Test Cases
All now correctly blocked:
- `podman rm -af` ✅ DENY
- `podman rm -fa` ✅ DENY  
- `podman rm -f container` ✅ DENY
- `podman rm --force container` ✅ DENY
- `podman rmi -af` ✅ DENY

## Context
An AI agent ran `podman rm -af` in a production environment and took down all services. DCG would have prevented this if the pattern had matched.