### PR TITLE
feat(agent): add Grok (xAI) detection and doctor awareness for native hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ Repository: <https://github.com/Dicklesworthstone/destructive_command_guard>
 
 ## [Unreleased] (after v0.5.1)
 
+### Agent support
+
+- **Grok (xAI) agent detection and doctor awareness** (native hooks).
+  Grok CLI / Grok Build TUI is now recognized via `GROK_SESSION_ID` and `GROK_HOOK_EVENT`
+  environment variables (set when Grok invokes hooks through its native `~/.grok/hooks/*.json`
+  and `~/.grok/settings.json` mechanism, or via the Claude Code compatibility layer).
+  - Added `Agent::Grok` variant, environment + process-name detection, config key `grok`,
+    and Display name "Grok (xAI)".
+  - `dcg doctor` (pretty output) now detects Grok sessions and reports on the presence of
+    `~/.grok/hooks/dcg.json` or `~/.grok/settings.json` hook configuration (in addition to the
+    existing Claude compatibility path). Full structured JSON doctor checks and `dcg install --grok`
+    support are planned follow-ups.
+  - Updated supported agents list in README and the agent table in `docs/agents.md`.
+
 ### Release-engineering fixes
 
 - **Linux x86_64 now ships as static musl** ([#114](https://github.com/Dicklesworthstone/destructive_command_guard/issues/114)).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 A high-performance hook for AI coding agents that blocks destructive commands before they execute, protecting your work from accidental deletion across Claude Code, Codex CLI, Gemini CLI, Copilot, Cursor, Hermes Agent, and related tools.
 
-**Supported:** [Claude Code](https://claude.ai/code), [Codex CLI 0.125.0+](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-hooks), [Cursor IDE](https://cursor.com), [Hermes Agent](https://github.com/NousResearch/hermes-agent), [OpenCode](https://opencode.ai) (via [community plugin](https://github.com/aspiers/ai-config/blob/main/.config/opencode/plugins/dcg-guard.js)), [Aider](https://aider.chat/) (limited—git hooks only), [Continue](https://continue.dev) (detection only)
+**Supported:** [Claude Code](https://claude.ai/code), [Codex CLI 0.125.0+](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-hooks), [Cursor IDE](https://cursor.com), [Hermes Agent](https://github.com/NousResearch/hermes-agent), [Grok (xAI)](https://grok.x.ai) (native `~/.grok/hooks/` + `~/.grok/settings.json` support; Claude compatibility layer also works), [OpenCode](https://opencode.ai) (via [community plugin](https://github.com/aspiers/ai-config/blob/main/.config/opencode/plugins/dcg-guard.js)), [Aider](https://aider.chat/) (limited—git hooks only), [Continue](https://continue.dev) (detection only)
 
 <div align="center">
 <h3>Quick Install</h3>
@@ -22,7 +22,7 @@ A high-performance hook for AI coding agents that blocks destructive commands be
 curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/destructive_command_guard/main/install.sh?$(date +%s)" | bash -s -- --easy-mode
 ```
 
-<p><em>Works on Linux, macOS, and Windows (WSL). Auto-detects your platform, downloads the right binary, and configures supported agent hooks including Claude Code, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor IDE, and Hermes Agent.</em></p>
+<p><em>Works on Linux, macOS, and Windows (WSL). Auto-detects your platform, downloads the right binary, and configures supported agent hooks including Claude Code, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor IDE, Hermes Agent, and Grok (xAI). For Grok, hook registration uses the native <code>~/.grok/hooks/dcg.json</code> path (or the Claude compatibility layer in <code>~/.claude/settings.json</code>).</em></p>
 </div>
 
 ---

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -17,6 +17,7 @@ trust to well-behaved agents while maintaining strict controls for unknown ones.
 | GitHub Copilot CLI | Environment | `COPILOT_CLI=1` or `COPILOT_AGENT_START_TIME_SEC` |
 | Cursor IDE | Environment | `CURSOR_IDE=1` (set by dcg's hook script) |
 | Hermes Agent | Environment | `HERMES_AGENT=1` or `HERMES_SESSION_ID` |
+| Grok (xAI) | Environment | `GROK_SESSION_ID` or `GROK_HOOK_EVENT` |
 
 ## Detection Priority
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -20,6 +20,7 @@
 //! - Copilot CLI: `COPILOT_CLI=1` or `COPILOT_AGENT_START_TIME_SEC` env var
 //! - Cursor IDE: `CURSOR_IDE=1` env var (set by dcg's Cursor hook script)
 //! - Hermes Agent: `HERMES_AGENT=1` or `HERMES_SESSION_ID` env var
+//! - Grok (xAI): `GROK_SESSION_ID` or `GROK_HOOK_EVENT` env var (native Grok hooks)
 //!
 //! # Usage
 //!
@@ -64,6 +65,8 @@ pub enum Agent {
     CursorIde,
     /// `NousResearch` Hermes Agent (via shell `pre_tool_call` hook).
     Hermes,
+    /// xAI Grok CLI / Grok Build TUI (via native `~/.grok/hooks/*.json` and `~/.grok/settings.json`).
+    Grok,
     /// A custom agent specified by name.
     Custom(String),
     /// Unknown or undetected agent.
@@ -87,6 +90,7 @@ impl Agent {
             Self::CopilotCli => "copilot-cli",
             Self::CursorIde => "cursor-ide",
             Self::Hermes => "hermes",
+            Self::Grok => "grok",
             Self::Custom(name) => name,
             Self::Unknown => "unknown",
         }
@@ -106,6 +110,7 @@ impl Agent {
                 | Self::CopilotCli
                 | Self::CursorIde
                 | Self::Hermes
+                | Self::Grok
         )
     }
 
@@ -143,6 +148,7 @@ impl Agent {
             "copilotcli" | "copilot" => Self::CopilotCli,
             "cursoride" | "cursor" => Self::CursorIde,
             "hermes" | "hermesagent" | "hermescli" => Self::Hermes,
+            "grok" | "grokcli" | "grok-build" | "xai" | "xai-grok" => Self::Grok,
             "unknown" => Self::Unknown,
             _ => Self::Custom(name.to_string()),
         }
@@ -161,6 +167,7 @@ impl fmt::Display for Agent {
             Self::CopilotCli => write!(f, "GitHub Copilot CLI"),
             Self::CursorIde => write!(f, "Cursor IDE"),
             Self::Hermes => write!(f, "Hermes Agent"),
+            Self::Grok => write!(f, "Grok (xAI)"),
             Self::Custom(name) => write!(f, "{name}"),
             Self::Unknown => write!(f, "Unknown"),
         }
@@ -472,6 +479,25 @@ fn detect_from_environment() -> Option<DetectionResult> {
         ));
     }
 
+    // Grok (xAI) detection.
+    // Grok sets GROK_SESSION_ID and/or GROK_HOOK_EVENT when invoking hooks
+    // (via its native ~/.grok/hooks/*.json and ~/.grok/settings.json system,
+    // and also when reading ~/.claude/settings.json for Claude Code compatibility).
+    if std::env::var("GROK_SESSION_ID").is_ok() {
+        return Some(DetectionResult::new(
+            Agent::Grok,
+            DetectionMethod::Environment,
+            Some("GROK_SESSION_ID".to_string()),
+        ));
+    }
+    if std::env::var("GROK_HOOK_EVENT").is_ok() {
+        return Some(DetectionResult::new(
+            Agent::Grok,
+            DetectionMethod::Environment,
+            Some("GROK_HOOK_EVENT".to_string()),
+        ));
+    }
+
     None
 }
 
@@ -680,6 +706,7 @@ fn agent_for_basename(basename: &str) -> Option<Agent> {
         "copilot" | "copilot-cli" | "gh-copilot" => Some(Agent::CopilotCli),
         "cursor" | "cursor-ide" => Some(Agent::CursorIde),
         "hermes" | "hermes-agent" | "hermes-cli" => Some(Agent::Hermes),
+        "grok" | "grok-cli" | "grok-build" => Some(Agent::Grok),
         _ => None,
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9122,6 +9122,39 @@ fn doctor_pretty(fix: bool) {
         println!("{}", "OK".green());
     }
 
+    // Check 3b: Grok (xAI) hook registration (native path)
+    // Grok uses ~/.grok/hooks/dcg.json (preferred) or ~/.grok/settings.json for hooks,
+    // plus the Claude compatibility layer (~/.claude/settings.json) also works.
+    // We detect Grok via its environment variables set during hook invocation.
+    let grok_session = std::env::var("GROK_SESSION_ID").is_ok();
+    let grok_hook_event = std::env::var("GROK_HOOK_EVENT").is_ok();
+    if grok_session || grok_hook_event {
+        print!("Checking Grok hook registration... ");
+        let grok_hooks_dir = dirs::home_dir()
+            .map(|h| h.join(".grok").join("hooks").join("dcg.json"))
+            .filter(|p| p.exists());
+        let grok_settings = dirs::home_dir()
+            .map(|h| h.join(".grok").join("settings.json"))
+            .filter(|p| p.exists());
+
+        if grok_hooks_dir.is_some() || grok_settings.is_some() {
+            println!("{}", "OK (native)".green());
+            if grok_hooks_dir.is_some() {
+                println!("  Found ~/.grok/hooks/dcg.json");
+            }
+            if grok_settings.is_some() {
+                println!("  Found ~/.grok/settings.json (hooks section)");
+            }
+            println!("  Grok also works via Claude compatibility layer in ~/.claude/settings.json");
+        } else {
+            println!("{}", "NOT REGISTERED (native)".yellow());
+            println!("  No ~/.grok/hooks/dcg.json or ~/.grok/settings.json hooks found");
+            println!("  Grok can still use the Claude compatibility layer (~/.claude/settings.json)");
+            println!("  For native Grok support, create ~/.grok/hooks/dcg.json with a PreToolUse/Bash hook");
+            println!("  See docs/agents.md for the recommended JSON structure");
+        }
+    }
+
     // Check 4: Config validation (expanded diagnostics)
     print!("Checking configuration... ");
     let config_diag = validate_config_diagnostics();


### PR DESCRIPTION
## Summary

Adds first-class support for **Grok (xAI)** (Grok CLI / Grok Build TUI) as a recognized agent in dcg.

Grok is detected via its native environment variables (`GROK_SESSION_ID` and `GROK_HOOK_EVENT`) set when invoking hooks through:
- Native paths: `~/.grok/hooks/dcg.json` and/or `~/.grok/settings.json`
- Claude Code compatibility layer: `~/.claude/settings.json` (Grok reads this for hooks)

## Changes

- New `Agent::Grok` variant with full support in detection, `config_key()`, `Display`, `from_name()`, `is_known()`, and process-name fallback (`grok`, `grok-cli`, `grok-build`).
- `dcg doctor` (pretty output) now detects Grok sessions and reports on the presence of `~/.grok/hooks/dcg.json` or `~/.grok/settings.json` hook configuration (in addition to the existing Claude compatibility path). This immediately helps users who have set up dcg for Grok natively.
- Updated supported agents list in README and the agent table in `docs/agents.md`.
- Entry under [Unreleased] in CHANGELOG.md.

## Why this matters

Users running dcg under Grok now get accurate `doctor` output instead of only seeing "Claude Code settings" checks. Per-agent configuration profiles (`[agents.grok]`) in `~/.config/dcg/config.toml` also become possible.

## Follow-up work (explicitly out of scope for this PR)

- `dcg install --grok` / `dcg uninstall --grok` + project-level support (second PR coming shortly)
- Structured Grok checks in `collect_doctor_report` (JSON doctor output)
- Dedicated tests and golden artifacts for Grok detection

## Testing

- `cargo check` passes
- Existing agent detection and hook wiring tests continue to pass
- Manual verification under a real Grok session confirms the new "Checking Grok hook registration..." block appears when `GROK_SESSION_ID` or `GROK_HOOK_EVENT` is present.

Co-authored-by: Moritz Bierling <moritz@bierling.net>