### PR TITLE
fix(packs): extend infrastructure.terraform pack to protect OpenTofu (tofu)

### DIFF
--- a/src/packs/infrastructure/terraform.rs
+++ b/src/packs/infrastructure/terraform.rs
@@ -1,4 +1,8 @@
-//! Terraform patterns - protections against destructive terraform commands.
+//! Terraform/OpenTofu patterns - protections against destructive commands.
+//!
+//! OpenTofu (`tofu`) is a drop-in fork of Terraform and shares the same
+//! subcommands, so every rule matches both the `terraform` and `tofu`
+//! binaries.
 //!
 //! This includes patterns for:
 //! - terraform destroy
@@ -15,9 +19,9 @@ pub fn create_pack() -> Pack {
     Pack {
         id: "infrastructure.terraform".to_string(),
         name: "Terraform",
-        description: "Protects against destructive Terraform operations like destroy, \
+        description: "Protects against destructive Terraform/OpenTofu operations like destroy, \
                       taint, and apply with -auto-approve",
-        keywords: &["terraform", "destroy", "taint", "state"],
+        keywords: &["terraform", "tofu", "destroy", "taint", "state"],
         safe_patterns: create_safe_patterns(),
         destructive_patterns: create_destructive_patterns(),
         keyword_matcher: None,
@@ -36,56 +40,56 @@ fn create_safe_patterns() -> Vec<SafePattern> {
         // plan is safe (read-only)
         safe_pattern!(
             "terraform-plan",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+plan(?=\s|$)(?!\s+.*-destroy)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+plan(?=\s|$)(?!\s+.*-destroy)"
         ),
         // init is safe
         safe_pattern!(
             "terraform-init",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+init(?=\s|$)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+init(?=\s|$)"
         ),
         // validate is safe
         safe_pattern!(
             "terraform-validate",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+validate(?=\s|$)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+validate(?=\s|$)"
         ),
         // fmt is safe
         safe_pattern!(
             "terraform-fmt",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+fmt(?=\s|$)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+fmt(?=\s|$)"
         ),
         // show is safe
         safe_pattern!(
             "terraform-show",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+show(?=\s|$)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+show(?=\s|$)"
         ),
         // output is safe
         safe_pattern!(
             "terraform-output",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+output(?=\s|$)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+output(?=\s|$)"
         ),
         // state list/show are safe (read-only)
         safe_pattern!(
             "terraform-state-list",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+state\s+list(?=\s|$)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+state\s+list(?=\s|$)"
         ),
         safe_pattern!(
             "terraform-state-show",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+state\s+show(?=\s|$)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+state\s+show(?=\s|$)"
         ),
         // graph is safe
         safe_pattern!(
             "terraform-graph",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+graph(?=\s|$)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+graph(?=\s|$)"
         ),
         // version is safe
         safe_pattern!(
             "terraform-version",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+version(?=\s|$)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+version(?=\s|$)"
         ),
         // providers is safe
         safe_pattern!(
             "terraform-providers",
-            r"terraform\b(?:\s+--?\S+(?:\s+\S+)?)*\s+providers(?=\s|$)"
+            r"(?:terraform|tofu)\b(?:\s+--?\S+(?:\s+\S+)?)*\s+providers(?=\s|$)"
         ),
     ]
 }
@@ -96,8 +100,8 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // broader destroy rule so the preview keeps its Medium severity.
         destructive_pattern!(
             "plan-destroy",
-            r"terraform\b.*?\bplan\s+.*-destroy",
-            "terraform plan -destroy shows what would be destroyed. Review carefully before applying.",
+            r"(?:terraform|tofu)\b.*?\bplan\s+.*-destroy",
+            "terraform/tofu plan -destroy shows what would be destroyed. Review carefully before applying.",
             Medium,
             "terraform plan -destroy shows destruction preview:\n\n\
              - This is a read-only operation (safe to run)\n\
@@ -109,8 +113,8 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // (a plan file literally named `destroy-plan.tf`) doesn't false-match.
         destructive_pattern!(
             "destroy",
-            r"terraform\b.*?\bdestroy(?=\s|$)",
-            "terraform destroy removes ALL managed infrastructure. Use 'terraform plan -destroy' first.",
+            r"(?:terraform|tofu)\b.*?\bdestroy(?=\s|$)",
+            "terraform/tofu destroy removes ALL managed infrastructure. Use 'terraform plan -destroy' first.",
             Critical,
             "terraform destroy removes ALL managed infrastructure:\n\n\
              - Every resource in your state file is destroyed\n\
@@ -122,8 +126,8 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // apply with -auto-approve (skips confirmation)
         destructive_pattern!(
             "apply-auto-approve",
-            r"terraform\b.*?\bapply\s+.*-auto-approve",
-            "terraform apply -auto-approve skips confirmation. Remove -auto-approve for safety.",
+            r"(?:terraform|tofu)\b.*?\bapply\s+.*-auto-approve",
+            "terraform/tofu apply -auto-approve skips confirmation. Remove -auto-approve for safety.",
             High,
             "terraform apply -auto-approve skips confirmation:\n\n\
              - No opportunity to review changes before applying\n\
@@ -134,8 +138,8 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // taint marks resource for recreation
         destructive_pattern!(
             "taint",
-            r"terraform\b.*?\btaint\b",
-            "terraform taint marks a resource to be destroyed and recreated on next apply.",
+            r"(?:terraform|tofu)\b.*?\btaint\b",
+            "terraform/tofu taint marks a resource to be destroyed and recreated on next apply.",
             High,
             "terraform taint marks resource for recreation:\n\n\
              - Resource will be destroyed on next apply\n\
@@ -147,8 +151,8 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // state rm removes from state (orphans resource)
         destructive_pattern!(
             "state-rm",
-            r"terraform\b.*?\bstate\s+rm\b",
-            "terraform state rm removes resource from state without destroying it. Resource becomes unmanaged.",
+            r"(?:terraform|tofu)\b.*?\bstate\s+rm\b",
+            "terraform/tofu state rm removes resource from state without destroying it. Resource becomes unmanaged.",
             High,
             "terraform state rm orphans resources:\n\n\
              - Resource removed from Terraform state\n\
@@ -160,8 +164,8 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // state mv can cause issues if done incorrectly
         destructive_pattern!(
             "state-mv",
-            r"terraform\b.*?\bstate\s+mv\b",
-            "terraform state mv moves resources in state. Incorrect moves can cause resource recreation.",
+            r"(?:terraform|tofu)\b.*?\bstate\s+mv\b",
+            "terraform/tofu state mv moves resources in state. Incorrect moves can cause resource recreation.",
             High,
             "terraform state mv moves resources in state:\n\n\
              - Renames resource address in state file\n\
@@ -173,8 +177,8 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // force-unlock
         destructive_pattern!(
             "force-unlock",
-            r"terraform\b.*?\bforce-unlock\b",
-            "terraform force-unlock removes state lock. Only use if lock is stale.",
+            r"(?:terraform|tofu)\b.*?\bforce-unlock\b",
+            "terraform/tofu force-unlock removes state lock. Only use if lock is stale.",
             High,
             "terraform force-unlock removes state locks:\n\n\
              - Forces removal of a state lock\n\
@@ -186,8 +190,8 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // workspace delete
         destructive_pattern!(
             "workspace-delete",
-            r"terraform\b.*?\bworkspace\s+delete\b",
-            "terraform workspace delete removes a workspace. Ensure it's not in use.",
+            r"(?:terraform|tofu)\b.*?\bworkspace\s+delete\b",
+            "terraform/tofu workspace delete removes a workspace. Ensure it's not in use.",
             Medium,
             "terraform workspace delete removes workspace:\n\n\
              - Workspace and its state file deleted\n\
@@ -328,5 +332,122 @@ mod tests {
         assert_no_match(&pack, "ls -la");
         assert_no_match(&pack, "git status");
         assert_no_match(&pack, "echo terraform");
+    }
+
+    // --- OpenTofu (`tofu`) parity ---------------------------------------
+    // OpenTofu is a drop-in fork of Terraform and shares the same CLI
+    // surface. Every rule that fires for `terraform <x>` must fire
+    // identically for `tofu <x>`. The keyword quick-reject gate in
+    // src/packs/mod.rs already lists "tofu"; these tests pin the patterns
+    // to it so a tofu command can never silently bypass the pack.
+
+    #[test]
+    fn tofu_blocks_each_destructive_pattern() {
+        let pack = create_pack();
+        assert_blocks(&pack, "tofu destroy", "destroy");
+        assert_blocks(&pack, "tofu plan -destroy", "plan -destroy");
+        assert_blocks(&pack, "tofu apply -auto-approve", "auto-approve");
+        assert_blocks(&pack, "tofu taint aws_instance.web", "taint");
+        assert_blocks(&pack, "tofu state rm aws_s3_bucket.data", "state rm");
+        assert_blocks(
+            &pack,
+            "tofu state mv aws_instance.a aws_instance.b",
+            "state mv",
+        );
+        assert_blocks(&pack, "tofu force-unlock 123", "force-unlock");
+        assert_blocks(&pack, "tofu workspace delete staging", "workspace delete");
+    }
+
+    #[test]
+    fn tofu_blocks_with_correct_severity() {
+        let pack = create_pack();
+        assert_blocks_with_severity(&pack, "tofu destroy", Severity::Critical);
+        assert_blocks_with_severity(&pack, "tofu plan -destroy", Severity::Medium);
+        assert_blocks_with_severity(&pack, "tofu apply -auto-approve", Severity::High);
+        assert_blocks_with_severity(&pack, "tofu taint aws_instance.x", Severity::High);
+        assert_blocks_with_severity(&pack, "tofu state rm aws_instance.x", Severity::High);
+        assert_blocks_with_severity(&pack, "tofu state mv a b", Severity::High);
+        assert_blocks_with_severity(&pack, "tofu force-unlock 123", Severity::High);
+        assert_blocks_with_severity(&pack, "tofu workspace delete dev", Severity::Medium);
+    }
+
+    #[test]
+    fn tofu_all_safe_patterns_match() {
+        let pack = create_pack();
+        assert_safe_pattern_matches(&pack, "tofu plan");
+        assert_safe_pattern_matches(&pack, "tofu init");
+        assert_safe_pattern_matches(&pack, "tofu validate");
+        assert_safe_pattern_matches(&pack, "tofu fmt");
+        assert_safe_pattern_matches(&pack, "tofu show");
+        assert_safe_pattern_matches(&pack, "tofu output");
+        assert_safe_pattern_matches(&pack, "tofu state list");
+        assert_safe_pattern_matches(&pack, "tofu state show aws_instance.web");
+        assert_safe_pattern_matches(&pack, "tofu graph");
+        assert_safe_pattern_matches(&pack, "tofu version");
+        assert_safe_pattern_matches(&pack, "tofu providers");
+    }
+
+    #[test]
+    fn tofu_interactive_apply_is_allowed() {
+        // Interactive `apply` (no -auto-approve) is intentionally NOT
+        // blocked. Parity with terraform, not stricter.
+        let pack = create_pack();
+        assert_allows(&pack, "tofu apply");
+        assert_allows(&pack, "terraform apply");
+    }
+
+    #[test]
+    fn tofu_patterns_match_with_chdir_flag() {
+        // The global `-chdir=<path>` flag precedes the subcommand for tofu
+        // exactly as it does for terraform.
+        let pack = create_pack();
+        assert_blocks(&pack, "tofu -chdir=./environments/prod destroy", "destroy");
+        assert_blocks(
+            &pack,
+            "tofu -chdir=./prod apply -auto-approve",
+            "auto-approve",
+        );
+        assert_blocks(
+            &pack,
+            "tofu -chdir=./prod state rm aws_instance.important",
+            "state",
+        );
+    }
+
+    #[test]
+    fn tofu_safe_patterns_do_not_bypass_via_flag_value() {
+        // A flag value like `-chdir=./plan-output` must not falsely match a
+        // safe pattern and bypass destructive rules for tofu either.
+        let pack = create_pack();
+        assert_allows(&pack, "tofu plan");
+        assert_allows(&pack, "tofu -chdir=./prod plan");
+        assert_allows(&pack, "tofu show");
+        assert_allows(&pack, "tofu state list");
+        // Genuine destructive still blocks
+        assert_blocks(&pack, "tofu destroy -auto-approve", "destroy");
+    }
+
+    #[test]
+    fn tofu_destroy_does_not_false_match_plan_file_name() {
+        // A plan file literally named `destroy-plan.tf` must not trip the
+        // destroy rule (the trailing `(?=\s|$)` guards this).
+        let pack = create_pack();
+        assert_allows(&pack, "tofu apply destroy-plan.tf");
+    }
+
+    #[test]
+    fn tofu_subcommand_as_substring_does_not_bypass() {
+        // A workspace named "plan-stack" must not trigger the safe
+        // "terraform-plan" pattern and allow "tofu destroy plan-stack".
+        let pack = create_pack();
+        assert_blocks(&pack, "tofu destroy plan-stack", "destroy");
+        assert_blocks(&pack, "tofu destroy init-resources", "destroy");
+    }
+
+    #[test]
+    fn tofu_unrelated_commands_no_match() {
+        let pack = create_pack();
+        assert_no_match(&pack, "echo tofu");
+        assert_no_match(&pack, "cat tofu-notes.txt");
     }
 }


### PR DESCRIPTION
Closes #167

## The bug

The `infrastructure.terraform` pack's keyword quick-reject gate already lists `tofu` alongside `terraform` (`src/packs/mod.rs`):

```rust
PackEntry::new(
    "infrastructure.terraform",
    &["terraform", "tofu"],
    infrastructure::terraform::create_pack,
),
```

That gate decides whether the pack's regexes run at all (`Pack::might_match`): if a command contains none of the keywords, the regexes are skipped. So a `tofu ...` command **clears the gate** — but every pattern in the pack was hard-anchored to the literal `terraform\b`. The patterns therefore ran, **none matched**, and the command was **ALLOWED**.

Net effect: OpenTofu users got **zero protection**. The gate listing `tofu` shows the intent was there; the patterns just never followed through. It's an oversight, not a deliberate choice — there is no separate OpenTofu pack.

## The fix

Replace the leading binary anchor `terraform\b` with `(?:terraform|tofu)\b` in **all 19 patterns** (11 safe + 8 destructive), preserving every lookahead, word boundary, and subcommand matcher byte-for-byte.

```diff
-    r"terraform\b.*?\bdestroy(?=\s|$)",
+    r"(?:terraform|tofu)\b.*?\bdestroy(?=\s|$)",
```

This gives full terraform↔tofu parity: every rule that fires for `terraform <x>` now fires identically for `tofu <x>`.

## Rules now covered for `tofu`

Destructive (unchanged severities): `plan -destroy` (Medium), `destroy` (Critical), `apply -auto-approve` (High), `taint` (High), `state rm` (High), `state mv` (High), `force-unlock` (High), `workspace delete` (Medium).

Safe / allowed (read-only): `plan`, `init`, `validate`, `fmt`, `show`, `output`, `state list`, `state show`, `graph`, `version`, `providers`.

## Interactive `apply` is unchanged (parity, not stricter)

Interactive `tofu apply` (without `-auto-approve`) is **intentionally NOT blocked** — exactly matching the existing `terraform apply` behavior. Only the `-auto-approve` variant blocks. This PR does not make the pack stricter; it only closes the terraform-only gap.

## Other changes

Purely cosmetic / metadata, scoped to this one pack:
- Pack `description`, `keywords`, and the module doc comment now mention OpenTofu.
- The 8 destructive `reason` strings now read `terraform/tofu ...` so the denial message is accurate when a `tofu` command is blocked.

No new rule types, no severity changes, no other packs, no installer changes.

## Tests

Added `tofu_*` tests mirroring the existing terraform suite:
- per-rule block coverage (`tofu destroy`, `tofu apply -auto-approve`, `tofu taint`, `tofu state rm`, `tofu state mv`, `tofu force-unlock`, `tofu workspace delete`, `tofu plan -destroy`);
- severity parity for all destructive rules;
- all 11 safe patterns match for `tofu`;
- interactive `tofu apply` (and `terraform apply`) stays allowed;
- the `-chdir=<path>` global flag;
- the four edge-case regression guards (flag-value bypass, plan-file-name false match, subcommand-substring bypass, unrelated-command no-match).

All existing terraform tests pass unchanged. `cargo test --lib packs::infrastructure::terraform` → 17 passed; `cargo fmt --check` and `cargo clippy --lib` are clean.
