### PR TITLE
fix: enforce path-scoped allowlists

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2616,6 +2616,7 @@ fn evaluate_batch_line(
     };
 
     // Evaluate the command
+    let project_path = std::env::current_dir().ok();
     let eval_result = evaluate_command_with_pack_order_deadline_at_path(
         &command,
         enabled_keywords,
@@ -2625,7 +2626,7 @@ fn evaluate_batch_line(
         allowlists,
         heredoc_settings,
         None,
-        None,
+        project_path.as_deref(),
         None, // No deadline for batch mode
     );
 
@@ -4072,6 +4073,7 @@ fn test_command(
     };
 
     // Use shared evaluator for consistent behavior with hook mode
+    let project_path = std::env::current_dir().ok();
     let start = Instant::now();
     let mut result = evaluate_command_with_pack_order_deadline_at_path(
         command,
@@ -4082,7 +4084,7 @@ fn test_command(
         &allowlists,
         &heredoc_settings,
         None, // allow_once_audit
-        None, // project_path
+        project_path.as_deref(),
         None, // deadline
     );
 
@@ -4603,6 +4605,7 @@ fn classify_command(config: &Config, command: &str, format: ClassifyFormat, no_c
     };
 
     // Evaluate the command
+    let project_path = std::env::current_dir().ok();
     let result = evaluate_command_with_pack_order_deadline_at_path(
         command,
         &enabled_keywords,
@@ -4612,7 +4615,7 @@ fn classify_command(config: &Config, command: &str, format: ClassifyFormat, no_c
         &allowlists,
         &heredoc_settings,
         None, // allow_once_audit
-        None, // project_path
+        project_path.as_deref(),
         None, // deadline
     );
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1381,16 +1381,16 @@ fn resolve_project_path(
     heredoc_settings: &crate::config::HeredocSettings,
     project_path: Option<&Path>,
 ) -> Option<PathBuf> {
+    if let Some(path) = project_path {
+        return Some(path.to_path_buf());
+    }
+
     if heredoc_settings
         .content_allowlist
         .as_ref()
         .is_none_or(|a| a.projects.is_empty())
     {
         return None;
-    }
-
-    if let Some(path) = project_path {
-        return Some(path.to_path_buf());
     }
 
     std::env::current_dir().ok()
@@ -2849,7 +2849,11 @@ fn evaluate_heredoc(
             if m.severity.blocks_by_default() {
                 let (pack_id, pattern_name) = split_ast_rule_id(&m.rule_id);
 
-                if let Some(hit) = context.allowlists.match_rule(&pack_id, &pattern_name) {
+                if let Some(hit) = context.allowlists.match_rule_at_path(
+                    &pack_id,
+                    &pattern_name,
+                    context.project_path,
+                ) {
                     if first_allowlist_hit.is_none() {
                         let reason =
                             format_heredoc_denial_reason(&content, &m, &pack_id, &pattern_name);
@@ -3016,7 +3020,11 @@ fn evaluate_heredoc(
 
             let (pack_id, pattern_name) = split_ast_rule_id(&m.rule_id);
 
-            if let Some(hit) = context.allowlists.match_rule(&pack_id, &pattern_name) {
+            if let Some(hit) =
+                context
+                    .allowlists
+                    .match_rule_at_path(&pack_id, &pattern_name, context.project_path)
+            {
                 if first_allowlist_hit.is_none() {
                     let reason =
                         format_heredoc_denial_reason(&content, &m, &pack_id, &pattern_name);
@@ -3086,7 +3094,11 @@ fn evaluate_heredoc(
                 if m.severity.blocks_by_default() {
                     let (pack_id, pattern_name) = split_ast_rule_id(&m.rule_id);
 
-                    if let Some(hit) = context.allowlists.match_rule(&pack_id, &pattern_name) {
+                    if let Some(hit) = context.allowlists.match_rule_at_path(
+                        &pack_id,
+                        &pattern_name,
+                        context.project_path,
+                    ) {
                         if first_allowlist_hit.is_none() {
                             let reason =
                                 format_heredoc_denial_reason(&content, &m, &pack_id, &pattern_name);
@@ -3511,7 +3523,7 @@ mod tests {
         AllowEntry, AllowSelector, AllowlistFile, LoadedAllowlistLayer, RuleId,
     };
     use std::collections::HashMap;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -3529,27 +3541,45 @@ mod tests {
     }
 
     fn evaluate_with_pack_ids(command: &str, pack_ids: &[&str]) -> EvaluationResult {
+        let allowlists = default_allowlists();
+        evaluate_with_pack_ids_at_path(command, pack_ids, &allowlists, None)
+    }
+
+    fn evaluate_with_pack_ids_at_path(
+        command: &str,
+        pack_ids: &[&str],
+        allowlists: &LayeredAllowlist,
+        project_path: Option<&Path>,
+    ) -> EvaluationResult {
         let enabled_packs: std::collections::HashSet<String> =
             pack_ids.iter().map(|id| (*id).to_string()).collect();
         let ordered_packs = crate::packs::REGISTRY.expand_enabled_ordered(&enabled_packs);
         let keyword_index = crate::packs::REGISTRY.build_enabled_keyword_index(&ordered_packs);
         let enabled_keywords = crate::packs::REGISTRY.collect_enabled_keywords(&enabled_packs);
         let compiled = default_compiled_overrides();
-        let allowlists = default_allowlists();
         let heredoc_settings = default_config().heredoc_settings();
 
-        evaluate_command_with_pack_order(
+        evaluate_command_with_pack_order_at_path(
             command,
             enabled_keywords.as_slice(),
             ordered_packs.as_slice(),
             keyword_index.as_ref(),
             &compiled,
-            &allowlists,
+            allowlists,
             &heredoc_settings,
+            project_path,
         )
     }
 
     fn project_allowlists_for_rule(rule: &str, reason: &str) -> LayeredAllowlist {
+        project_allowlists_for_rule_at_paths(rule, reason, None)
+    }
+
+    fn project_allowlists_for_rule_at_paths(
+        rule: &str,
+        reason: &str,
+        paths: Option<Vec<String>>,
+    ) -> LayeredAllowlist {
         let rule = RuleId::parse(rule).expect("rule id must parse");
         LayeredAllowlist {
             layers: vec![LoadedAllowlistLayer {
@@ -3568,7 +3598,7 @@ mod tests {
                         context: None,
                         conditions: HashMap::new(),
                         environments: Vec::new(),
-                        paths: None,
+                        paths,
                         risk_acknowledged: false,
                     }],
                     errors: Vec::new(),
@@ -4352,6 +4382,54 @@ mod tests {
         );
         assert!(result.is_allowed());
         assert!(result.allowlist_override.is_some());
+    }
+
+    #[test]
+    fn path_scoped_allowlist_applies_only_at_matching_path() {
+        let allowlists = project_allowlists_for_rule_at_paths(
+            "core.git:reset-hard",
+            "allowed project only",
+            Some(vec!["/allowed/**".to_string()]),
+        );
+        let outside = evaluate_with_pack_ids_at_path(
+            "git reset --hard",
+            &["core.git"],
+            &allowlists,
+            Some(Path::new("/outside")),
+        );
+        assert!(outside.is_denied());
+
+        let inside = evaluate_with_pack_ids_at_path(
+            "git reset --hard",
+            &["core.git"],
+            &allowlists,
+            Some(Path::new("/allowed/project")),
+        );
+        assert!(inside.is_allowed());
+        assert!(inside.allowlist_override.is_some());
+    }
+
+    #[test]
+    fn path_scoped_allowlist_applies_to_heredoc_ast_matches() {
+        let allowlists = project_allowlists_for_rule_at_paths(
+            "heredoc.python:shutil_rmtree",
+            "allowed project only",
+            Some(vec!["/allowed/**".to_string()]),
+        );
+        let command = "python3 - <<PY\nimport shutil\nshutil.rmtree(\"/etc\")\nPY";
+
+        let outside =
+            evaluate_with_pack_ids_at_path(command, &[], &allowlists, Some(Path::new("/outside")));
+        assert!(outside.is_denied());
+
+        let inside = evaluate_with_pack_ids_at_path(
+            command,
+            &[],
+            &allowlists,
+            Some(Path::new("/allowed/project")),
+        );
+        assert!(inside.is_allowed());
+        assert!(inside.allowlist_override.is_some());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -713,7 +713,7 @@ fn main() {
         &allowlists,
         &heredoc_settings,
         None, // allow_once_audit
-        None, // project_path
+        cwd_path.as_deref(),
         Some(&deadline),
     );
 

--- a/tests/codex_hook_protocol.rs
+++ b/tests/codex_hook_protocol.rs
@@ -11,7 +11,7 @@
 
 use std::fmt;
 use std::io::{ErrorKind, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 // ---------------------------------------------------------------------------
@@ -1969,6 +1969,15 @@ fn codex_allow_once_round_trip() {
 
 /// Helper: spawn dcg with a hermetic HOME that has an allowlist.toml.
 fn run_with_user_allowlist(allowlist_toml: &str, command: &str, use_codex: bool) -> HookOutcome {
+    run_with_user_allowlist_at_path(allowlist_toml, command, use_codex, None)
+}
+
+fn run_with_user_allowlist_at_path(
+    allowlist_toml: &str,
+    command: &str,
+    use_codex: bool,
+    cwd: Option<&Path>,
+) -> HookOutcome {
     let home = tempfile::tempdir().expect("tempdir");
     let config_dir = home.path().join(".config/dcg");
     std::fs::create_dir_all(&config_dir).unwrap();
@@ -1994,6 +2003,10 @@ fn run_with_user_allowlist(allowlist_toml: &str, command: &str, use_codex: bool)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+
+    if let Some(cwd) = cwd {
+        cmd.current_dir(cwd);
+    }
 
     let mut child = cmd.spawn().expect("spawn");
     {
@@ -2035,6 +2048,47 @@ reason = "Team accepts this risk in CI"
     assert!(
         outcome.is_allow_shape(),
         "user allowlist rule must produce silent allow under Claude\n{outcome}"
+    );
+}
+
+#[test]
+fn path_scoped_allowlist_only_applies_inside_configured_path() {
+    let repo = tempfile::tempdir().expect("repo tempdir");
+    std::fs::create_dir(repo.path().join(".git")).expect("create git marker");
+    std::fs::create_dir(repo.path().join(".dcg")).expect("create dcg dir");
+    let allowed_project = repo.path().join("allowed/project");
+    let outside_project = repo.path().join("outside");
+    std::fs::create_dir_all(&allowed_project).expect("create allowed project");
+    std::fs::create_dir(&outside_project).expect("create outside project");
+    let allowlist = r#"
+[[allow]]
+rule = "core.git:reset-hard"
+reason = "allowed project only"
+paths = ["**/allowed/**"]
+"#;
+    std::fs::write(repo.path().join(".dcg/allowlist.toml"), allowlist)
+        .expect("write project allowlist");
+
+    let denied = run_with_user_allowlist_at_path(
+        "",
+        "git reset --hard HEAD~1",
+        true,
+        Some(&outside_project),
+    );
+    assert!(
+        denied.is_codex_block_shape(),
+        "path-scoped rule must not apply outside configured path\n{denied}"
+    );
+
+    let allowed = run_with_user_allowlist_at_path(
+        "",
+        "git reset --hard HEAD~1",
+        true,
+        Some(&allowed_project),
+    );
+    assert!(
+        allowed.is_allow_shape(),
+        "path-scoped rule must apply inside configured path\n{allowed}"
     );
 }
 

--- a/tests/test_command.rs
+++ b/tests/test_command.rs
@@ -125,6 +125,46 @@ reason = "test fixture allowlist entry"
 }
 
 #[test]
+fn test_path_scoped_allowlist_only_applies_inside_configured_path() {
+    let repo = tempfile::tempdir().expect("temp repo");
+    std::fs::create_dir(repo.path().join(".git")).expect("create .git marker");
+    std::fs::create_dir(repo.path().join(".dcg")).expect("create .dcg dir");
+    let allowed = repo.path().join("allowed/project");
+    let outside = repo.path().join("outside");
+    std::fs::create_dir_all(&allowed).expect("create allowed dir");
+    std::fs::create_dir(&outside).expect("create outside dir");
+    std::fs::write(
+        repo.path().join(".dcg/allowlist.toml"),
+        r#"
+[[allow]]
+rule = "core.git:reset-hard"
+reason = "allowed project only"
+paths = ["**/allowed/**"]
+"#,
+    )
+    .expect("write allowlist");
+
+    let denied = run_dcg_isolated(
+        &["test", "--format", "json", "git reset --hard"],
+        Some(&outside),
+    );
+    assert_eq!(denied.status.code(), Some(1));
+    assert_eq!(parse_json(&denied)["decision"], "deny");
+
+    let allowed = run_dcg_isolated(
+        &["test", "--format", "json", "git reset --hard"],
+        Some(&allowed),
+    );
+    assert_eq!(
+        allowed.status.code(),
+        Some(0),
+        "path-scoped allowlist should apply inside configured path\nstderr: {}",
+        stderr_text(&allowed)
+    );
+    assert_eq!(parse_json(&allowed)["decision"], "allow");
+}
+
+#[test]
 fn test_json_output_has_expected_fields() {
     let output = run_dcg_isolated(&["test", "--format", "json", "git reset --hard"], None);
     let json = parse_json(&output);


### PR DESCRIPTION
## Summary

- pass the current working directory through hook, batch, test, and classify evaluation paths
- preserve explicit project paths independently of heredoc content-allowlist configuration
- enforce path scopes in every heredoc AST allowlist branch
- add evaluator, CLI, and Codex hook regression coverage for deny-outside / allow-inside behavior

## Root cause

The shared project-path resolver was originally gated by project-scoped heredoc allowlists. General allowlist matching later reused that value, so configurations without heredoc project entries resolved to `None`. Path-aware matchers intentionally skip path checks when no path is supplied, which made `paths = [...]` entries act globally. Several production entrypoints also passed `None` despite having a current working directory.

## Impact

Path-scoped allowlist entries now apply only within their configured paths across normal hooks, batch hooks, `dcg test`, `dcg classify`, and heredoc AST matches.

## Validation

- `cargo check --all-targets`
- targeted evaluator unit tests for normal and heredoc AST matches
- subprocess tests for `dcg test` and Codex hook path scoping
- Clippy with warnings denied for the changed production and test targets
- `rustfmt --check`
- independent final diff review