### PR TITLE
Fix dcg packs printing literal [bold]/[dim]/[green] instead of styling

### DIFF
--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -9,9 +9,13 @@
 //! for premium terminal output. Otherwise, a fallback ASCII tree renderer is used.
 
 #[cfg(feature = "rich-output")]
+use rich_rust::markup::render_or_plain;
+#[cfg(feature = "rich-output")]
 use rich_rust::renderables::tree::{Tree as RichTree, TreeGuides, TreeNode as RichTreeNode};
 #[cfg(feature = "rich-output")]
 use rich_rust::style::Style;
+#[cfg(feature = "rich-output")]
+use rich_rust::text::Text as RichText;
 
 use super::theme::{BorderStyle, Theme};
 use crate::evaluator::EvaluationDecision;
@@ -324,10 +328,22 @@ impl TreeNode {
     /// Convert to rich_rust TreeNode (when feature enabled).
     #[cfg(feature = "rich-output")]
     fn to_rich_node(&self) -> RichTreeNode {
+        // TreeNode::new()/with_icon() accept `impl Into<Text>`, and a bare
+        // String/&str goes through Text::new() — which does NOT parse markup
+        // (see rich_rust's own doc comment on TreeNode::new). Passing the
+        // raw "[style]label[/]" string through unparsed is exactly why the
+        // bracket tags showed up literally in `dcg packs` output instead of
+        // being rendered as color/bold. render_or_plain() does the parsing
+        // rich_rust expects the caller to do before construction.
+        //
+        // Only styled labels go through render_or_plain: an unstyled label
+        // may legitimately contain literal '[' (e.g. `extra_packs =
+        // ["paranoid"]`, see #187) and must NOT be run through the markup
+        // parser, which would try to interpret those brackets as tags.
         let label = if let Some(ref style) = self.style {
-            format!("{style}{}{style_end}", self.label, style_end = "[/]")
+            render_or_plain(&format!("{style}{}{style_end}", self.label, style_end = "[/]"))
         } else {
-            self.label.clone()
+            RichText::new(self.label.clone())
         };
 
         let mut node = if let Some(ref icon) = self.icon {
@@ -1308,6 +1324,47 @@ mod tests {
     fn test_tree_node_styled() {
         let node = TreeNode::new("styled").styled("[bold red]");
         assert_eq!(node.style.as_deref(), Some("[bold red]"));
+    }
+
+    // Regression tests for #187: `dcg packs` printed literal "[bold]"/"[dim]"/
+    // "[green]" tags instead of applying the styling. Root cause: TreeNode::new()
+    // accepts `impl Into<Text>`, and a bare String goes through Text::new(),
+    // which rich_rust documents as NOT parsing markup — the raw
+    // "[style]label[/]" string was never being interpreted.
+    #[cfg(feature = "rich-output")]
+    #[test]
+    fn test_to_rich_node_parses_style_markup_instead_of_leaving_it_literal() {
+        let node = TreeNode::new("No packs to display").styled("[dim]");
+        let rich = node.to_rich_node();
+
+        let plain = rich.label().plain();
+        assert!(
+            !plain.contains("[dim]") && !plain.contains("[/]"),
+            "markup tags leaked into rendered text: {plain:?}"
+        );
+        assert_eq!(plain, "No packs to display");
+
+        // Parsed markup must actually apply styling, not just silently strip
+        // the tags (which would look identical to unstyled text). rich_rust's
+        // Text::style() is the *base* style — markup parsing applies styling
+        // via per-range spans instead, so that's what to check here.
+        assert!(
+            !rich.label().spans().is_empty(),
+            "expected [dim] markup to produce at least one styled span, got none: {:?}",
+            rich.label().spans()
+        );
+    }
+
+    #[cfg(feature = "rich-output")]
+    #[test]
+    fn test_to_rich_node_unstyled_label_keeps_literal_brackets() {
+        // An unstyled label may legitimately contain '[' as real content
+        // (e.g. `extra_packs = ["paranoid"]`, see #187) and must NOT be run
+        // through the markup parser, or those brackets would be
+        // misinterpreted as tag syntax.
+        let node = TreeNode::new(r#"extra_packs = ["paranoid"]"#);
+        let rich = node.to_rich_node();
+        assert_eq!(rich.label().plain(), r#"extra_packs = ["paranoid"]"#);
     }
 
     #[test]


### PR DESCRIPTION
Addresses the "Display (Concrete Bug)" item in #187 only — not the `--verbose` performance issue or the documentation clarity points in the same issue, which are separate concerns.

## Root cause

`TreeNode::to_rich_node()` builds a `"[style]label[/]"` markup string and passes it straight to `RichTreeNode::new()` / `with_icon()`, which accept `impl Into<Text>`. A bare `String` goes through `Text::new()` — which `rich_rust`'s own doc comment states does **not** parse markup:

> Passing a `&str` uses `Text::new()` and does **NOT** parse markup. For styled labels, pass a pre-styled `Text` (e.g. from `crate::markup::render_or_plain`).

The unparsed markup was rendered as literal text — exactly the reported bug.

## Fix

Styled labels now go through `rich_rust::markup::render_or_plain()` before construction, matching what the dependency's docs say callers must do. Unstyled labels deliberately do **not** go through the markup parser — a plain label can legitimately contain literal `[` (e.g. `extra_packs = ["paranoid"]`, from #187's docs section), and running it through `render_or_plain` would misinterpret those brackets as markup syntax.

## Verification — being upfront about a sandbox limitation

I could not get `cargo test` / `cargo build --release` to complete in my environment:
- The release link fails on an unrelated MinGW `__imp_atan` multiple-definition conflict pulled in by `aws-lc-sys`/tree-sitter (reproduces even with `-Wl,--allow-multiple-definition`).
- `cargo check` separately hits an `aws-lc-sys` C compilation failure in the same environment.

Neither touches `src/output/tree.rs` or `rich_rust`, so I don't believe either is related to this change, but I want to be explicit that I have **not** run this repo's actual test suite against my diff.

To verify the fix logic itself, I extracted the exact changed code into an isolated crate depending only on the real `rich_rust = "0.2.2"` (crates.io, `markdown` feature) and wrote 3 tests there:
1. The fixed `to_rich_node()` logic strips `[dim]`/`[/]` and leaves no literal markup in the plain-text output, with styling actually present as a span (`Text::style()` is the *base* style, not what markup parsing sets — my first draft of this assertion checked the wrong thing and caught itself failing, which is how I found that distinction).
2. The unstyled-label path leaves literal `[` alone, unparsed.
3. A negative control: the **pre-fix** logic, run against the same input, does leak `"[dim]"`/`"[/]"` as literal text — confirming the bug is real and test 1 is a genuine regression test, not a tautology.

All 3 passed. The two applicable tests (not the negative control, which doesn't apply once the fix is in) are included in this PR's diff, in the existing `tests` module in `src/output/tree.rs` — but I have not been able to run *those* through `cargo` here, for the reasons above. Happy to iterate if CI turns up anything my isolated repro didn't catch.