### PR TITLE
docs(packs): fix bogus extra_packs examples and document category expansion (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Tip: Consider using 'git stash' first to save your changes.
 [packs]
 enabled = [
     "database.postgresql",    # Blocks DROP TABLE, TRUNCATE
-    "kubernetes.kubectl",     # Blocks kubectl delete namespace
+    "kubernetes",             # Category ID — enables all kubernetes.* sub-packs
     "cloud.aws",              # Blocks aws ec2 terminate-instances
     "containers.docker",      # Blocks docker system prune
 ]
@@ -113,7 +113,7 @@ disabled_packs = ["kubernetes"]
 # Restrict unknown agents — extra rules, no allowlist bypass
 [agents.unknown]
 trust_level = "low"
-extra_packs = ["paranoid"]
+extra_packs = ["strict_git", "database"]  # real pack / category IDs (not graduation modes)
 disabled_allowlist = true
 ```
 
@@ -168,6 +168,8 @@ If dcg is blocking something you genuinely need to run:
 ## Modular Pack System
 
 dcg uses a modular "pack" system to organize destructive command patterns by category. Packs can be enabled or disabled in the configuration file.
+
+Category IDs expand to every sub-pack under them: `enabled = ["database"]` turns on `database.postgresql`, `database.mysql`, and the rest of that category. You can still disable individual sub-packs with `disabled = ["database.redis"]`. The same expansion applies to agent-profile `extra_packs` / `disabled_packs`. Use real pack or category IDs from `dcg packs` / `docs/packs/README.md` — names like `"paranoid"` are [graduation modes](docs/graduated-response.md), not packs.
 
 - Full pack ID index: `docs/packs/README.md`
 - Canonical descriptions + pattern counts: `dcg packs --verbose`

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -96,7 +96,10 @@ the allowlist so every command is evaluated against the full rule set:
 [agents.unknown]
 trust_level = "low"
 disabled_allowlist = true
-extra_packs = ["core", "database", "filesystem"]
+# Real pack / category IDs (see `dcg packs` / docs/packs/README.md).
+# Category IDs like "database" expand to every database.* sub-pack.
+# "paranoid" is a graduation mode, not a pack — use strict_git for extra git rules.
+extra_packs = ["strict_git", "database", "system"]
 ```
 
 ## Configuration
@@ -113,7 +116,7 @@ additional_allowlist = ["npm run build", "cargo test"]
 [agents.unknown]
 trust_level = "low"
 disabled_allowlist = true
-extra_packs = ["paranoid"]
+extra_packs = ["strict_git", "database"]
 
 # Default profile for unspecified agents
 [agents.default]
@@ -125,8 +128,8 @@ trust_level = "medium"
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `trust_level` | string | `"medium"` | Advisory label: `"high"`, `"medium"`, or `"low"`. Included in JSON/verbose output but does not change rule evaluation by itself. |
-| `disabled_packs` | array | `[]` | Packs to remove from evaluation for this agent (including sub-packs). |
-| `extra_packs` | array | `[]` | Additional packs to enable for this agent. |
+| `disabled_packs` | array | `[]` | Pack or category IDs to remove from evaluation for this agent (category IDs drop every matching sub-pack). |
+| `extra_packs` | array | `[]` | Additional pack or category IDs to enable for this agent (category IDs expand to all sub-packs). |
 | `additional_allowlist` | array | `[]` | Command patterns to allowlist for this agent (added on top of the base allowlist). |
 | `disabled_allowlist` | bool | `false` | If `true`, ignore all allowlist entries for this agent (more restrictive). |
 
@@ -137,7 +140,7 @@ trust_level = "medium"
 [agents.unknown]
 trust_level = "low"
 disabled_allowlist = true
-extra_packs = ["core", "database", "filesystem"]
+extra_packs = ["strict_git", "database", "system"]
 
 [agents.claude-code]
 trust_level = "medium"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,13 +21,18 @@ Enable or disable packs in config files:
 enabled = [
   "database.postgresql",
   "containers.docker",
-  "kubernetes", # enables all kubernetes sub-packs
+  "kubernetes", # category ID — enables all kubernetes.* sub-packs
 ]
 
 disabled = [
-
+  # "database.redis",  # optional: keep a category enabled but drop one sub-pack
 ]
 ```
+
+Category IDs in `enabled` / `disabled` (and in agent-profile `extra_packs` /
+`disabled_packs`) expand to every matching sub-pack. Use IDs from `dcg packs` or
+`docs/packs/README.md`. Names such as `"paranoid"` are [graduation modes](graduated-response.md),
+not packs — for stricter git rules enable the real `strict_git` pack instead.
 
 ### Environment Overrides
 
@@ -225,7 +230,7 @@ additional_allowlist = ["npm run build"]
 
 [agents.unknown]
 trust_level = "low"
-extra_packs = ["paranoid"]
+extra_packs = ["strict_git", "database"]
 ```
 
 See [agents.md](agents.md) for full documentation on agent detection, trust


### PR DESCRIPTION
## Summary
Addresses the **documentation clarity** items in #187 that #188 explicitly left out of scope (display markup bug only). Agent-profile examples were suggesting pack IDs that do not exist, and category expansion was easy to miss unless you already knew the modular pack system.

## Problem
Several docs copied the same misleading snippets:

```toml
extra_packs = ["paranoid"]
# and
extra_packs = ["core", "database", "filesystem"]
```

- `"paranoid"` is a [graduation mode](docs/graduated-response.md) (`GraduationMode::Paranoid`), not a pack ID. `enabled_pack_ids_for_agent` inserts the string into the pack set, so this was a silent no-op.
- `"filesystem"` is not a category; the real pack is `core.filesystem`, and the category is `core`.
- Category expansion (`enabled = ["kubernetes"]` → all `kubernetes.*` sub-packs) was only hinted at in `docs/configuration.md`, so users who only read the README had to discover it by experiment — exactly as reported in #187.

## Solution
- Replace bogus `extra_packs` examples in `README.md`, `docs/agents.md`, and `docs/configuration.md` with real IDs: `strict_git` (the tier-9 “extra paranoid git” pack) plus category IDs like `database` / `system`.
- Document category expansion next to the Modular Pack System / Pack Configuration sections, including that the same rules apply to agent-profile `extra_packs` / `disabled_packs`.
- Call out that `"paranoid"` is a graduation mode so it is not confused with a pack again.
- Show a category ID in the README “Enable More Protection” example (`"kubernetes"`).

## Out of scope
- The `dcg packs` markup rendering bug — already covered by #188.
- The `--verbose` performance hang reported in #187 — separate concern; needs profiling, not a docs change.
- No Rust / installer changes.

## Test plan
- [x] `git grep 'extra_packs = \["paranoid"\]'` / `filesystem` examples — no remaining bogus config values in the touched docs
- [x] Cross-checked replacement IDs against `src/packs/mod.rs` (`strict_git` pack entry; `database` / `system` / `kubernetes` categories)
- [ ] CI / docs preview if applicable

## Related
- #187 — docs clarity section (category enablement + fake `paranoid` example)
- #188 — sibling PR for the display/markup bug from the same issue

Made with [Cursor](https://cursor.com)