### PR TITLE
fix(core.filesystem): allow double-quoted /tmp and /var/tmp deletes

### DIFF
--- a/src/packs/core/filesystem.rs
+++ b/src/packs/core/filesystem.rs
@@ -667,6 +667,16 @@ fn path_is_safe_unquoted(path: &str) -> bool {
 }
 
 fn path_is_safe_double_quoted(path: &str) -> bool {
+    // Literal /tmp and /var/tmp are unchanged by double quotes (bash quoting
+    // only affects expansion and word splitting, not literal path text). Without
+    // parity with path_is_safe_unquoted, `rm -rf "/tmp/foo"` falsely trips the
+    // CRITICAL root/home rule while `rm -rf /tmp/foo` is allowed.
+    if let Some(rest) = path.strip_prefix("/tmp/") {
+        return !has_dotdot_segment(rest);
+    }
+    if let Some(rest) = path.strip_prefix("/var/tmp/") {
+        return !has_dotdot_segment(rest);
+    }
     if let Some(rest) = path.strip_prefix("$TMPDIR/") {
         return !has_dotdot_segment(rest);
     }
@@ -3451,6 +3461,26 @@ mod tests {
             r#"rm --force --recursive "${TMPDIR}/foo""#,
             RM_RECURSIVE_FORCE_NAME,
             Severity::High,
+        );
+    }
+
+    #[test]
+    fn test_rm_parser_allows_literal_tmp_double_quoted() {
+        // Regression for #201: double quotes around /tmp and /var/tmp are
+        // shell-transparent (bash quoting only affects expansion and word
+        // splitting, not literal text). `rm -rf "/tmp/foo"` must have parity
+        // with `rm -rf /tmp/foo` — previously the quoted form was falsely
+        // classified as a CRITICAL root/home deletion.
+        assert_rm_parser_allows(r#"rm -rf "/tmp/foo""#);
+        assert_rm_parser_allows(r#"rm -rf "/tmp/build/artifacts""#);
+        assert_rm_parser_allows(r#"rm -rf "/var/tmp/cache""#);
+
+        // Dot-dot traversal inside the quoted path must still deny (parity
+        // with the unquoted `has_dotdot_segment` guard).
+        assert_rm_parser_denies(
+            r#"rm -rf "/tmp/../etc""#,
+            RM_RF_ROOT_HOME_NAME,
+            Severity::Critical,
         );
     }
 


### PR DESCRIPTION
Fixes #201.

## Summary

`path_is_safe_double_quoted` in `src/packs/core/filesystem.rs` missed the two literal temp prefixes (`/tmp/`, `/var/tmp/`) that its unquoted twin recognizes. That made `rm -rf "/tmp/foo"` trip the CRITICAL root/home rule while `rm -rf /tmp/foo` was allowed — a documented safe pattern (README §Temp cleanup) with the strongest deny classification.

Bash double quotes are transparent to literal path text; they only affect variable/glob expansion and word splitting. So the quoted and unquoted forms must behave identically for these prefixes.

## Change

- Add `/tmp/` and `/var/tmp/` prefix checks to `path_is_safe_double_quoted` for parity with `path_is_safe_unquoted`. `has_dotdot_segment` still guards against `..` traversal, matching the unquoted branch.
- New regression test `test_rm_parser_allows_literal_tmp_double_quoted` covers the allow cases (`rm -rf "/tmp/foo"`, `rm -rf "/var/tmp/cache"`) and the traversal-deny case (`rm -rf "/tmp/../etc"` → still Critical).

## Test plan

Verified locally against the pinned nightly (`nightly-2026-06-06-aarch64-apple-darwin`):

- [x] `cargo test --lib packs::core::filesystem::tests::test_rm_parser_allows_literal_tmp_double_quoted` — **pass**
- [x] `cargo test --lib packs::core::filesystem::tests::test_rm_parser_allows_tmpdir_quotes` — **pass** (unchanged, still green)
- [x] `cargo test --lib packs::core::filesystem::tests::test_rm_parser_traversal_blocked` — **pass** (unchanged, still green)

Combined run: `3 passed; 0 failed; 0 ignored`.