### PR TITLE
fix(strict_git): block force-refspec push to main/master

### DIFF
--- a/src/packs/strict_git/mod.rs
+++ b/src/packs/strict_git/mod.rs
@@ -120,15 +120,18 @@ fn create_destructive_patterns() -> Vec<DestructivePattern> {
         // Block push to master. Separators include `/` so explicit refspecs
         // like `HEAD:refs/heads/master` are caught — `main` appearing after
         // `/` in `refs/heads/main` used to bypass the old `[\s:]` separator.
+        // `\+?` before the branch name catches the force-refspec shorthand
+        // (`git push origin +master`), which is semantically identical to
+        // `--force` and used to slip past both push-master and push-force-any.
         destructive_pattern!(
             "push-master",
-            r"git\s+(?:\S+\s+)*push\s+(?:.*[\s:/])?master(?:\s|$)",
+            r"git\s+(?:\S+\s+)*push\s+(?:.*[\s:/])?\+?master(?:\s|$)",
             "Direct push to master is blocked. Use a feature branch and open a Pull Request."
         ),
         // Block push to main
         destructive_pattern!(
             "push-main",
-            r"git\s+(?:\S+\s+)*push\s+(?:.*[\s:/])?main(?:\s|$)",
+            r"git\s+(?:\S+\s+)*push\s+(?:.*[\s:/])?\+?main(?:\s|$)",
             "Direct push to main is blocked. Use a feature branch and open a Pull Request."
         ),
     ]
@@ -279,5 +282,50 @@ mod tests {
             "git push origin refs/heads/master",
             "Direct push to master is blocked",
         );
+    }
+
+    #[test]
+    fn test_push_force_refspec_prefix() {
+        // Regression for #202: the `+` refspec prefix is git's shorthand for a
+        // forced (non-fast-forward) update. Semantically identical to --force.
+        // Previously bypassed both push-main/master and push-force-any.
+        let pack = create_pack();
+        assert_blocks(
+            &pack,
+            "git push origin +main",
+            "Direct push to main is blocked",
+        );
+        assert_blocks(
+            &pack,
+            "git push origin +master",
+            "Direct push to master is blocked",
+        );
+        assert_blocks(
+            &pack,
+            "git push origin +HEAD:main",
+            "Direct push to main is blocked",
+        );
+        assert_blocks(
+            &pack,
+            "git push origin +HEAD:master",
+            "Direct push to master is blocked",
+        );
+        assert_blocks(
+            &pack,
+            "git push origin +refs/heads/main",
+            "Direct push to main is blocked",
+        );
+        assert_blocks(
+            &pack,
+            "git push origin +refs/heads/master",
+            "Direct push to master is blocked",
+        );
+
+        // The `+` only counts as a refspec marker when it sits immediately
+        // before the branch token, so unrelated branch names that happen to
+        // contain the branch substring must still be allowed (guard against
+        // over-broadening the separator character class).
+        assert_allows(&pack, "git push origin feature-main");
+        assert_allows(&pack, "git push origin main-fix");
     }
 }


### PR DESCRIPTION
Fixes #202.

## Summary

`git push origin +main` is git's shorthand for a forced update to `main` (see `git push` docs, REFSPEC section) and is semantically equivalent to `--force`. It bypassed both `push-main`/`push-master` (which needed a `[\s:/]` separator immediately before the branch name, and `+` is neither) and `push-force-any` (which only matched literal `--force`/`--force-with-lease`/`-f`).

Result: the whole point of the strict pack — blocking force pushes to default branches — could be sidestepped by any agent aware of the `+ref` shorthand.

## Change

- Add `\+?` immediately before the branch token in `push-main` and `push-master`. Narrow placement (before the branch specifically, not in the general separator class) preserves the existing false-positive guards for names like `feature-main`, `main-fix`, `feature-master`.
- New test `test_push_force_refspec_prefix` covers `+main`, `+master`, `+HEAD:main`, `+HEAD:master`, `+refs/heads/main`, `+refs/heads/master`, and re-asserts the previous allow cases.

Deliberately kept minimal: the general `+ref` force form (`git push origin +some-branch`) is a related but separate rule that `push-force-any` could learn — happy to file a follow-up if wanted.

## Test plan

Verified locally against the pinned nightly (`nightly-2026-06-06-aarch64-apple-darwin`) with `cargo test --lib packs::strict_git::tests`:

- [x] `test_push_force_refspec_prefix` (new) — **pass**
- [x] `test_push_main` (unchanged) — **pass**
- [x] `test_push_master` (unchanged) — **pass**
- [x] `test_push_master_refspec` (unchanged) — **pass**
- [x] `strict_git_patterns_match_with_git_global_flags`, `test_add_all_dot`, `test_add_all_flag` (unchanged) — **pass**

Full module run: `7 passed; 0 failed; 0 ignored`.