### PR TITLE
fix(output): recognize `n` as a falsey env flag value

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -230,12 +230,12 @@ fn env_flag_os_value_enabled(value: &std::ffi::OsStr) -> bool {
 /// Returns whether a DCG-owned environment flag value is enabled.
 ///
 /// These semantics intentionally match the CLI's documented boolean env
-/// parsing: empty string, `0`, `false`, `no`, and `off` are disabled; every
-/// other UTF-8 value is enabled.
+/// parsing: empty string, `0`, `false`, `no`, `n`, and `off` are disabled;
+/// every other UTF-8 value is enabled.
 pub fn env_flag_value_enabled(value: &str) -> bool {
     !matches!(
         value.trim().to_lowercase().as_str(),
-        "" | "0" | "false" | "no" | "off"
+        "" | "0" | "false" | "no" | "n" | "off"
     )
 }
 
@@ -378,7 +378,10 @@ mod tests {
             assert!(env_flag_value_enabled(value), "{value:?} should be enabled");
         }
 
-        for value in ["", "0", "false", "no", "off", " FALSE "] {
+        // Regression for #203: `n` must be recognized as disabled so that
+        // env_flag_value_enabled stays in lockstep with the CLI's
+        // parse_env_bool, which treats `n` as false.
+        for value in ["", "0", "false", "no", "n", "N", "off", " FALSE ", " n "] {
             assert!(
                 !env_flag_value_enabled(value),
                 "{value:?} should be disabled"


### PR DESCRIPTION
Fixes #203.

## Summary

`env_flag_value_enabled` in `src/output/mod.rs` is documented as matching the CLI's boolean env parsing (`parse_env_bool` in `src/config.rs`), but `n` was missing from its falsey arm. So `DCG_NO_COLOR=n` / `DCG_ROBOT=n` / `DCG_HIGH_CONTRAST=n` were treated as enabled while the CLI parser would treat the same value as false — a small inconsistency, but the docstring explicitly promises the two parsers agree.

For reference, `parse_env_bool` (`src/config.rs:4391`) and `env_disable_flag_enabled` (`src/config.rs:4399`) both list `n` alongside `no` in their falsey arms.

## Change

- Add `"n"` to the falsey `matches!` arm in `env_flag_value_enabled`. Trim + `to_lowercase` already handle `N`, ` n `, etc.
- Extend `test_env_flag_value_enabled_boolean_semantics` to cover `n`, `N`, and ` n `.

## Test plan

Verified locally against the pinned nightly (`nightly-2026-06-06-aarch64-apple-darwin`) with `cargo test --lib output::tests`:

- [x] `test_env_flag_value_enabled_boolean_semantics` (extended) — **pass**
- [x] All 24 other `output::tests::*` (unchanged, sanity check) — **pass**

Full module run: `25 passed; 0 failed; 0 ignored`.
