### PR TITLE
fix(allowlist): fall back to cwd for project allowlist outside git repos

### DIFF
--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -1461,8 +1461,7 @@ pub fn resolve_path_for_matching(
 pub fn load_default_allowlists() -> LayeredAllowlist {
     let project = std::env::current_dir()
         .ok()
-        .and_then(|cwd| find_repo_root(&cwd))
-        .map(|root| root.join(".dcg").join("allowlist.toml"));
+        .map(|cwd| project_allowlist_path(&cwd));
 
     // Check XDG-style path first (~/.config/dcg/), then platform-native
     let user = dirs::home_dir()
@@ -1485,6 +1484,20 @@ pub fn load_default_allowlists() -> LayeredAllowlist {
     );
 
     LayeredAllowlist::load_from_paths(project, user, system)
+}
+
+/// Resolve the project allowlist path for `cwd`, falling back to `cwd`
+/// itself when no `.git` ancestor is found.
+///
+/// This mirrors the CLI's write-side fallback (`allowlist_path_for_layer` in
+/// cli.rs): `--project` writes to `<cwd>/.dcg/allowlist.toml` even outside a
+/// git repo. The read side must fall back the same way, or a project
+/// allowlist created outside a git repo is silently never loaded (dcg#199).
+fn project_allowlist_path(cwd: &Path) -> PathBuf {
+    find_repo_root(cwd)
+        .unwrap_or_else(|| cwd.to_path_buf())
+        .join(".dcg")
+        .join("allowlist.toml")
 }
 
 fn find_repo_root(start: &Path) -> Option<PathBuf> {
@@ -1779,6 +1792,32 @@ fn get_timestamp_string(tbl: &toml::value::Table, key: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ----- project allowlist path resolution (dcg#199) -----
+
+    #[test]
+    fn project_allowlist_path_falls_back_to_cwd_outside_git_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No `.git` anywhere under tmp, so this must resolve to tmp itself,
+        // matching what the CLI's `--project` write path already does.
+        assert_eq!(
+            project_allowlist_path(tmp.path()),
+            tmp.path().join(".dcg").join("allowlist.toml")
+        );
+    }
+
+    #[test]
+    fn project_allowlist_path_uses_repo_root_when_git_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        let nested = tmp.path().join("a").join("b");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(
+            project_allowlist_path(&nested),
+            tmp.path().join(".dcg").join("allowlist.toml")
+        );
+    }
 
     // ----- command_prefix tail-injection regression tests -----
 


### PR DESCRIPTION
## Summary

Fixes #199 — `dcg allowlist add --project` outside a git repo reported success but the entry had no effect and wasn't even shown by `dcg allowlist list --project`.

## Root cause

Two code paths resolve the project allowlist path, and only one of them had a fallback for "no `.git` ancestor found":

- **Write path** (`allowlist_path_for_layer` in `cli.rs`): falls back to `current_dir()` when `find_repo_root_from_cwd()` returns `None`. This is why `add --project` "succeeds" outside a git repo.
- **Read path** (`load_default_allowlists` in `allowlist.rs`): had no fallback — `.and_then(|cwd| find_repo_root(&cwd))` yields `None` when there's no `.git` ancestor, so `LayeredAllowlist::load_from_paths` never even constructs a `Project` layer. Both command evaluation and `dcg allowlist list --project` read from this loaded set, so the file the write path created is invisible to both.

## Fix

Extracted the resolution into a single `project_allowlist_path(cwd: &Path) -> PathBuf` helper that applies the same fallback (`find_repo_root(cwd).unwrap_or_else(|| cwd.to_path_buf())`) as the existing write-side function, and pointed `load_default_allowlists` at it. No change to write-side behavior; no change to the git-repo case (the read path already worked correctly there — only the "no git ancestor" case was broken).

## Testing

- Added two unit tests covering the fallback (`project_allowlist_path_falls_back_to_cwd_outside_git_repo`) and the existing git-repo-anchored case still resolving to the repo root from a nested subdirectory (`project_allowlist_path_uses_repo_root_when_git_present`).
- `cargo test --lib allowlist::` — 100 passed, 0 failed (no regressions in the existing allowlist suite).
- `cargo fmt --check` — clean.
- `cargo clippy --lib -- -D warnings` — clean.

## Disclosure

Prepared with AI assistance (Claude Code). I read the relevant `allowlist.rs`/`cli.rs` code paths to confirm the exact write/read asymmetry described above before making the change, ran the full allowlist test suite plus fmt/clippy locally, and added regression coverage for both the fixed case and the pre-existing git-repo case to guard against reintroducing this asymmetry.