### PR TITLE
fix: prove literal redirect variable targets

### DIFF
--- a/docs/design/dcg-redirection-false-positive-hardening.md
+++ b/docs/design/dcg-redirection-false-positive-hardening.md
@@ -1,0 +1,130 @@
+# DCG redirection false-positive hardening
+
+Status: design gate; no evaluator or policy code changed yet
+Branch: `fix/shell-redirection-false-positives`
+Date: 2026-07-31
+
+## Problem statement
+
+DCG must distinguish shell syntax from inert command data without weakening its protection against truncation. The observed incidents came from four superficially similar strings that have different semantics:
+
+1. a real redirect whose target variable was assigned a fixed `/tmp` path earlier in the same command;
+2. `>` bytes inside quoted JavaScript, TypeScript, `find -printf`, JSX, SQL, and heredoc bodies;
+3. Docker's `run --rm` container-lifecycle option, which is not host-file deletion and is not `docker rm`;
+4. real redirects to an unbound/dynamic target, which must continue to require approval.
+
+The safety objective is not “permit more `>`”. It is to recognize the actual shell redirect token, classify its actual target, and make denials explain the exact token and approval scope.
+
+## Current evidence
+
+The installed binary is DCG 0.6.7. Upstream `main` and release 0.7.8 already include issue #225's quote-aware redirect handling in `src/evaluator.rs` and `tests/repro_redirect_quoted_data.rs`. The evaluator now finds an unquoted output redirect before applying `core.filesystem` redirect rules. Release 0.7.8 allows the previously blocked `find ... -printf '%f -> %l\n'` form while still denying a genuine redirect to `/etc/passwd`.
+
+A release-binary differential probe produced this matrix:
+
+| Case | 0.6.7 | 0.7.8 | Desired |
+|---|---|---|---|
+| literal `> /tmp/gcp-multi-poll.log` | allow | allow | allow |
+| quoted `find -printf '%f -> %l'` | deny | allow | allow |
+| quoted Node/TypeScript arrow data | allow in minimized probe | allow | allow |
+| `docker run --rm ...` | allow | allow | allow |
+| fixed relative evidence log | allow | allow | allow |
+| `> "$RUN_DIR/evidence.log"` with unresolved variable | deny | deny | deny |
+| `> /etc/passwd` | deny | deny | deny |
+| `log=/tmp/gcp-multi-poll.log; : > "$log"` | deny | deny | allow after literal assignment proof |
+
+This narrows the remaining code defect: quote handling and Docker `run --rm` are already correct upstream; simple prior-assignment constant propagation is absent. The 0.7.8 denial correctly reports `matched_span`, but robot output does not yet render the matched token or normalized target as human-readable fields.
+
+The local Cargo 1.75 toolchain cannot compile this Rust 2024 repository, which pins `nightly-2026-06-06`. Design evidence therefore uses the checksum-verified 0.7.8 release binary. Implementation must not begin until the pinned toolchain is available and the source tests can run.
+
+## Owner and impact surface
+
+The rule owner is `core.filesystem`, with pattern definitions in `src/packs/core/filesystem.rs`. Shell-syntax ownership is in `src/evaluator.rs`, primarily `first_unquoted_output_redirect`, `filesystem_redirection_matching_view`, and `evaluate_core_filesystem_pack`. Existing public output ownership is in `src/hook.rs` and the JSON schemas.
+
+The first PR should remain inside evaluator semantics and regression tests. It must not change IoA, agent hooks, local allowlists, Docker pack severities, or the installed `/usr/local/bin/dcg`. Approval-record schema and hook-output schema changes are separate follow-ups because they have different persistence and compatibility risks.
+
+## Proposed first PR: literal redirect-target resolution
+
+Add a narrow POSIX-shell resolver for redirects whose target is exactly `$NAME`, `${NAME}`, `"$NAME"`, or `"${NAME}"`. It may resolve a value only when all of these are true:
+
+- a preceding top-level segment in the same submitted command assigns `NAME` once;
+- the assignment value is one literal shell word after quote removal;
+- the value contains no parameter expansion, command/process substitution, glob, brace expansion, tilde-user expansion, backslash-obfuscated traversal, `eval`, or control operator;
+- no intervening segment mutates, exports dynamically, unsets, or indirectly references the variable;
+- the redirect has no concatenated dynamic prefix or suffix in the first slice.
+
+The resolved target must then pass the same sensitive-path classification as a direct literal redirect. `/etc`, root/home/system targets remain denied. Relative literals and literal `/tmp` or `/var/tmp` paths retain the existing direct-literal policy; this PR must not invent a broader writable-path allowlist.
+
+For a path that already exists, the resolver should fail closed when `symlink_metadata` reports a symlink or a non-regular file. For a missing target, inspect the nearest existing parent without following a final target component and reject a symlinked parent chain. On Unix, an existing target must be owned by the invoking user. These checks reduce obvious symlink substitution but cannot eliminate the time-of-check/time-of-use race created by the shell's later `O_TRUNC`; documentation must state that a private `0700` run directory is stronger than a shared `/tmp` basename.
+
+If any proof is missing, preserve today's `redirect-truncate-dynamic-path` denial. Do not guess from variable names such as `LOG`, and do not add a blanket `/tmp` bypass.
+
+## Denial diagnostics follow-up
+
+A subsequent output-focused PR should expose, without changing allow/deny behavior:
+
+- the exact redirect operator span;
+- the exact raw target token span;
+- a normalized target only when statically provable;
+- the unresolved feature that forced denial, such as `parameter-expansion`, `command-substitution`, `glob`, or `symlink`;
+- the narrow approval scope accepted by the current command.
+
+`matched_span` already provides a source-map foundation. New fields require updates to `src/hook.rs`, JSON schemas, robot/Codex protocol tests, and redaction review. They should not be mixed into the constant-propagation PR.
+
+## Approval semantics follow-up
+
+Current allow-once records bind to exact raw command plus cwd and expire after 24 hours. That is safer than a global bypass but does not yet bind a normalized redirect path, agent session, or shorter operator-selected timebox.
+
+A separate design is required for an approval tuple such as:
+
+```text
+command_hash + cwd_realpath + rule_id + normalized_target + agent/session + expires_at + single_use
+```
+
+Redemption must re-resolve cwd and target, re-run no-follow/type/owner checks, and refuse changed symlink or path identity. The existing 24-hour record format must not be silently reinterpreted. No global `DCG_BYPASS`, permanent broad allowlist, or rule disablement is part of this work.
+
+## Docker boundary
+
+`docker run --rm` is already allowed and covered by `tests/containers_pack_comprehensive.rs`. `docker rm -f`, `docker volume rm`, Compose volume removal, and host filesystem deletion remain separate destructive rules. Add the observed Node `-e` diagnostic form to the existing Docker allow regression corpus only if it reproduces against source HEAD; do not weaken `containers.docker:rm-force` to solve a command-string parsing bug.
+
+## Regression matrix for implementation
+
+The first PR's red tests belong beside the existing redirect regressions and must cover:
+
+### Must allow
+
+- `log=/tmp/gcp-multi-poll.log; : > "$log"`
+- assignment using single quotes and redirect using `${log}`
+- a fixed repository-relative evidence path assigned before use
+- quoted JavaScript arrows, JSX strings, SQL comparison operators, and `find -printf '%f -> %l'`
+- `docker run --rm ... -e '... => ...'`
+
+### Must deny
+
+- unbound `$log`
+- assignment from `$(...)`, backticks, another variable, glob, `eval`, or escaped traversal
+- reassignment between proof and redirect
+- literal assignment to `/etc/passwd`, `$HOME`, root, or another sensitive path
+- existing symlink target and symlinked parent
+- non-regular target
+- genuine redirect outside quotes, including the anti-bypass `"git">/dev/null reset --hard`
+- `docker rm -f`, `docker volume rm`, and Compose volume deletion
+
+### Evidence gates
+
+- focused redirect and container tests red before implementation and green after;
+- `cargo test --test repro_redirect_quoted_data` plus the new focused regression;
+- `cargo test`;
+- `cargo check --all-targets`;
+- `cargo clippy --all-targets -- -D warnings`;
+- `cargo fmt --check`;
+- differential checks against the installed 0.6.7 binary and checksum-verified 0.7.8 release;
+- `git diff --check` and a clean feature branch before PR creation.
+
+## Non-goals
+
+- modifying IoA code or its feature branches;
+- replacing the shell with a full interpreter;
+- proving arbitrary shell dataflow across functions, loops, subshells, sourced files, or `eval`;
+- globally trusting `/tmp`;
+- allowing Docker removal operations because `docker run --rm` is safe;
+- installing an unreleased DCG build into `/usr/local/bin` before upstream review and local acceptance.

--- a/docs/design/dcg-redirection-false-positive-hardening.md
+++ b/docs/design/dcg-redirection-false-positive-hardening.md
@@ -1,6 +1,6 @@
 # DCG redirection false-positive hardening
 
-Status: design gate; no evaluator or policy code changed yet
+Status: first evaluator slice implemented on the feature branch; not installed
 Branch: `fix/shell-redirection-false-positives`
 Date: 2026-07-31
 
@@ -49,12 +49,12 @@ Add a narrow POSIX-shell resolver for redirects whose target is exactly `$NAME`,
 - a preceding top-level segment in the same submitted command assigns `NAME` once;
 - the assignment value is one literal shell word after quote removal;
 - the value contains no parameter expansion, command/process substitution, glob, brace expansion, tilde-user expansion, backslash-obfuscated traversal, `eval`, or control operator;
-- no intervening segment mutates, exports dynamically, unsets, or indirectly references the variable;
-- the redirect has no concatenated dynamic prefix or suffix in the first slice.
+- no intervening executable segment exists, except a no-op `:` initializer redirect to the same proven target;
+- the redirect has no concatenated dynamic prefix or suffix, additional path redirect, or dynamic file-descriptor target.
 
 The resolved target must then pass the same sensitive-path classification as a direct literal redirect. `/etc`, root/home/system targets remain denied. Relative literals and literal `/tmp` or `/var/tmp` paths retain the existing direct-literal policy; this PR must not invent a broader writable-path allowlist.
 
-For a path that already exists, the resolver should fail closed when `symlink_metadata` reports a symlink or a non-regular file. For a missing target, inspect the nearest existing parent without following a final target component and reject a symlinked parent chain. On Unix, an existing target must be owned by the invoking user. These checks reduce obvious symlink substitution but cannot eliminate the time-of-check/time-of-use race created by the shell's later `O_TRUNC`; documentation must state that a private `0700` run directory is stronger than a shared `/tmp` basename.
+For a path that already exists, the resolver fails closed when `symlink_metadata` reports a symlink or a non-regular file. A missing target requires an existing, checked parent; every existing path component is inspected without following symlinks. On Unix, an existing target must be owned by the invoking effective user, and the parent must have that owner unless it is a sticky world-writable directory such as `/tmp`. These checks reduce obvious symlink substitution but cannot eliminate the time-of-check/time-of-use race created by the shell's later `O_TRUNC`; a private `0700` run directory remains stronger than a shared `/tmp` basename.
 
 If any proof is missing, preserve today's `redirect-truncate-dynamic-path` denial. Do not guess from variable names such as `LOG`, and do not add a blanket `/tmp` bypass.
 

--- a/docs/design/dcg-redirection-false-positive-hardening.md
+++ b/docs/design/dcg-redirection-false-positive-hardening.md
@@ -44,7 +44,7 @@ The first PR should remain inside evaluator semantics and regression tests. It m
 
 ## Proposed first PR: literal redirect-target resolution
 
-Add a narrow POSIX-shell resolver for redirects whose target is exactly `$NAME`, `${NAME}`, `"$NAME"`, or `"${NAME}"`. It may resolve a value only when all of these are true:
+Add a narrow Linux POSIX-shell resolver for redirects whose target is exactly `$NAME`, `${NAME}`, `"$NAME"`, or `"${NAME}"`. Non-Linux platforms retain the existing fail-closed decision until they have an equally trustworthy effective-user identity source. It may resolve a value only when all of these are true:
 
 - a preceding top-level segment in the same submitted command assigns `NAME` once;
 - the assignment value is one literal shell word after quote removal;

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -18878,6 +18878,14 @@ fn filesystem_redirect_pattern(name: Option<&str>) -> bool {
     )
 }
 
+fn filesystem_redirect_pattern_without_dynamic(name: Option<&str>) -> bool {
+    name == Some("redirect-truncate-root-home")
+}
+
+fn filesystem_pre_rm_pattern_without_dynamic(name: Option<&str>) -> bool {
+    filesystem_pre_rm_pattern(name) && name != Some("redirect-truncate-dynamic-path")
+}
+
 fn filesystem_non_pre_rm_pattern(name: Option<&str>) -> bool {
     !filesystem_pre_rm_pattern(name)
 }
@@ -18989,6 +18997,270 @@ fn filesystem_redirection_matching_view(command: &str, dialect: ShellDialect) ->
     Cow::Owned(String::from_utf8(view).expect("ASCII mask plus UTF-8 suffix remains valid UTF-8"))
 }
 
+fn trailing_redirect_syntax_is_fd_only(trailing: &str) -> bool {
+    trailing.split_ascii_whitespace().all(|token| {
+        if token == "&" {
+            return true;
+        }
+        let Some((from, to)) = token.split_once(">&") else {
+            return false;
+        };
+        !from.is_empty()
+            && !to.is_empty()
+            && from.bytes().all(|byte| byte.is_ascii_digit())
+            && to.bytes().all(|byte| byte.is_ascii_digit())
+    })
+}
+
+fn exact_redirect_variable(segment: &str, dialect: ShellDialect) -> Option<&str> {
+    if !matches!(dialect, ShellDialect::Unknown | ShellDialect::Posix) {
+        return None;
+    }
+    let redirect = first_unquoted_output_redirect(segment, ShellDialect::Posix)?;
+    let mut target = segment.get(redirect + 1..)?.trim_start();
+    if let Some(rest) = target.strip_prefix('|') {
+        target = rest.trim_start();
+    }
+
+    let (token, trailing) = if let Some(rest) = target.strip_prefix('"') {
+        let end = rest.find('"')?;
+        let token = rest.get(..end)?;
+        let trailing = rest.get(end + 1..)?;
+        if !trailing.is_empty()
+            && !trailing.as_bytes().first().is_some_and(|byte| {
+                byte.is_ascii_whitespace() || matches!(byte, b';' | b'|' | b'&')
+            })
+        {
+            return None;
+        }
+        (token, trailing)
+    } else {
+        let end = target
+            .find(|ch: char| ch.is_ascii_whitespace() || matches!(ch, ';' | '|' | '&'))
+            .unwrap_or(target.len());
+        (target.get(..end)?, target.get(end..)?)
+    };
+    if first_unquoted_output_redirect(trailing, ShellDialect::Posix).is_some()
+        && !trailing_redirect_syntax_is_fd_only(trailing)
+    {
+        return None;
+    }
+
+    let name = token
+        .strip_prefix("${")
+        .and_then(|rest| rest.strip_suffix('}'))
+        .or_else(|| token.strip_prefix('$'))?;
+    (!name.is_empty()
+        && name.bytes().enumerate().all(|(index, byte)| {
+            byte == b'_' || byte.is_ascii_alphabetic() || (index > 0 && byte.is_ascii_digit())
+        }))
+    .then_some(name)
+}
+
+fn literal_assignment_value(segment: &str, variable: &str) -> Option<String> {
+    let segment = segment.trim();
+    let raw = segment.strip_prefix(variable)?.strip_prefix('=')?;
+    if raw.is_empty() {
+        return None;
+    }
+
+    let value = if raw.starts_with('\'') && raw.ends_with('\'') && raw.len() >= 2 {
+        raw.get(1..raw.len() - 1)?.to_string()
+    } else if raw.starts_with('"') && raw.ends_with('"') && raw.len() >= 2 {
+        let inner = raw.get(1..raw.len() - 1)?;
+        if inner.contains(['$', '`', '\\']) {
+            return None;
+        }
+        inner.to_string()
+    } else {
+        if !raw.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'/' | b':')
+        }) {
+            return None;
+        }
+        raw.to_string()
+    };
+
+    (!value.is_empty()
+        && !value.starts_with('~')
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || byte.is_ascii_whitespace()
+                || matches!(byte, b'_' | b'-' | b'.' | b'/' | b':')
+        }))
+    .then_some(value)
+}
+
+fn is_literal_redirect_initializer(segment: &str, variable: &str) -> bool {
+    let Some(redirect) = first_unquoted_output_redirect(segment, ShellDialect::Posix) else {
+        return false;
+    };
+    segment
+        .get(..redirect)
+        .is_some_and(|prefix| prefix.trim() == ":")
+        && exact_redirect_variable(segment, ShellDialect::Posix) == Some(variable)
+}
+
+fn prior_literal_assignment(
+    command: &str,
+    segment_ranges: &[(usize, usize)],
+    redirect_segment_start: usize,
+    variable: &str,
+) -> Option<String> {
+    let mut assignment = None;
+    for &(start, end) in segment_ranges {
+        if end > redirect_segment_start {
+            continue;
+        }
+        let segment = command.get(start..end)?.trim();
+        if segment.is_empty() {
+            continue;
+        }
+        if let Some(rest) = segment.strip_prefix(variable)
+            && rest.starts_with('=')
+        {
+            if assignment.is_some() {
+                return None;
+            }
+            assignment = Some(literal_assignment_value(segment, variable)?);
+        } else if assignment.is_some() && !is_literal_redirect_initializer(segment, variable) {
+            // Shell functions and builtins can mutate variables in the parent
+            // shell. Apart from a no-op initializer redirect to the same
+            // proven target, keep the proof local to the assignment.
+            return None;
+        }
+    }
+    assignment
+}
+
+fn target_has_sensitive_absolute_prefix(path: &Path) -> bool {
+    let mut components = path.components();
+    if !matches!(components.next(), Some(std::path::Component::RootDir)) {
+        return false;
+    }
+    let Some(std::path::Component::Normal(first)) = components.next() else {
+        return true;
+    };
+    if first == "tmp" {
+        return false;
+    }
+    matches!(
+        first.to_str(),
+        Some(
+            "etc"
+                | "usr"
+                | "bin"
+                | "sbin"
+                | "root"
+                | "boot"
+                | "lib"
+                | "lib64"
+                | "var"
+                | "home"
+                | "sys"
+                | "proc"
+                | "dev"
+                | "opt"
+        )
+    )
+}
+
+fn fixed_redirect_target_is_safe(value: &str, project_path: Option<&Path>) -> bool {
+    let value_path = Path::new(value);
+    if value_path.components().any(|component| {
+        matches!(
+            component,
+            std::path::Component::ParentDir | std::path::Component::CurDir
+        )
+    }) || target_has_sensitive_absolute_prefix(value_path)
+    {
+        return false;
+    }
+
+    let base = project_path
+        .map(Path::to_path_buf)
+        .or_else(|| std::env::current_dir().ok());
+    let Some(path) = (if value_path.is_absolute() {
+        Some(value_path.to_path_buf())
+    } else {
+        base.as_ref().map(|base| base.join(value_path))
+    }) else {
+        return false;
+    };
+
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt;
+    #[cfg(unix)]
+    let Some(expected_uid) = std::fs::metadata("/proc/self")
+        .ok()
+        .map(|metadata| metadata.uid())
+    else {
+        // Without a safe effective-UID source, retain the dynamic-path denial.
+        return false;
+    };
+
+    let mut current = std::path::PathBuf::new();
+    let components: Vec<_> = path.components().collect();
+    for (index, component) in components.iter().enumerate() {
+        current.push(component.as_os_str());
+        let is_target = index + 1 == components.len();
+        let metadata = match std::fs::symlink_metadata(&current) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                if is_target {
+                    break;
+                }
+                continue;
+            }
+            Err(_) => return false,
+        };
+        if metadata.file_type().is_symlink()
+            || (is_target && !metadata.file_type().is_file())
+            || (!is_target && !metadata.file_type().is_dir())
+        {
+            return false;
+        }
+        #[cfg(unix)]
+        if is_target && metadata.uid() != expected_uid {
+            return false;
+        }
+    }
+
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Ok(parent_metadata) = std::fs::symlink_metadata(parent) else {
+        return false;
+    };
+    if parent_metadata.file_type().is_symlink() || !parent_metadata.file_type().is_dir() {
+        return false;
+    }
+    #[cfg(unix)]
+    let sticky_world_writable = parent_metadata.mode() & 0o1002 == 0o1002;
+    if parent_metadata.uid() != expected_uid && !sticky_world_writable {
+        return false;
+    }
+    true
+}
+
+fn redirect_target_has_proven_literal_assignment(
+    command: &str,
+    segment_ranges: &[(usize, usize)],
+    segment_start: usize,
+    segment: &str,
+    dialect: ShellDialect,
+    project_path: Option<&Path>,
+) -> bool {
+    let Some(variable) = exact_redirect_variable(segment, dialect) else {
+        return false;
+    };
+    let Some(value) = prior_literal_assignment(command, segment_ranges, segment_start, variable)
+    else {
+        return false;
+    };
+    fixed_redirect_target_is_safe(&value, project_path)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn evaluate_core_filesystem_pack(
     pack_id: &str,
@@ -19029,6 +19301,14 @@ fn evaluate_core_filesystem_pack(
         }
     }
 
+    let original_ranges = (original_command.len() == command_for_packs.len())
+        .then(|| command_segment_ranges_in_dialect(original_command, shell_dialect));
+    let (assignment_source, assignment_ranges) = original_ranges
+        .as_deref()
+        .map_or((command_for_packs, segment_ranges), |ranges| {
+            (original_command, ranges)
+        });
+
     for &(segment_start, segment_end) in segment_ranges {
         if deadline_exceeded(deadline) || remaining_below(deadline, &crate::perf::PATTERN_MATCH) {
             return Some(EvaluationResult::indeterminate_due_to_budget());
@@ -19066,6 +19346,26 @@ fn evaluate_core_filesystem_pack(
                     && !(nested_start == segment_start && nested_end == segment_end)
             })
             .collect();
+        let target_has_proven_literal_assignment = redirect_target_has_proven_literal_assignment(
+            assignment_source,
+            assignment_ranges,
+            segment_start,
+            dialect_segment,
+            shell_dialect,
+            project_path,
+        );
+        let redirect_pattern_filter: fn(Option<&str>) -> bool =
+            if target_has_proven_literal_assignment {
+                filesystem_redirect_pattern_without_dynamic
+            } else {
+                filesystem_redirect_pattern
+            };
+        let pre_rm_pattern_filter: fn(Option<&str>) -> bool =
+            if target_has_proven_literal_assignment {
+                filesystem_pre_rm_pattern_without_dynamic
+            } else {
+                filesystem_pre_rm_pattern
+            };
 
         // Redirect operators are shell syntax, not argv. Legacy callers with
         // no proven dialect retain the full sanitized command so the generic
@@ -19086,7 +19386,7 @@ fn evaluate_core_filesystem_pack(
                 first_allowlist_hit,
                 deadline,
                 &nested_segment_ranges,
-                Some(filesystem_redirect_pattern),
+                Some(redirect_pattern_filter),
             ) {
                 return Some(result);
             }
@@ -19111,7 +19411,7 @@ fn evaluate_core_filesystem_pack(
                 first_allowlist_hit,
                 deadline,
                 &nested_segment_ranges,
-                Some(filesystem_redirect_pattern),
+                Some(redirect_pattern_filter),
             ) {
                 return Some(result);
             }
@@ -19151,7 +19451,7 @@ fn evaluate_core_filesystem_pack(
             first_allowlist_hit,
             deadline,
             &nested_segment_ranges,
-            Some(filesystem_pre_rm_pattern),
+            Some(pre_rm_pattern_filter),
         ) {
             return Some(result);
         }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -19251,6 +19251,9 @@ fn redirect_target_has_proven_literal_assignment(
     dialect: ShellDialect,
     project_path: Option<&Path>,
 ) -> bool {
+    if !cfg!(target_os = "linux") {
+        return false;
+    }
     let Some(variable) = exact_redirect_variable(segment, dialect) else {
         return false;
     };

--- a/tests/repro_redirect_literal_assignment.rs
+++ b/tests/repro_redirect_literal_assignment.rs
@@ -1,0 +1,133 @@
+//! A truncating redirect through a shell variable is safe only when DCG can
+//! prove that the variable has one prior literal assignment and the resolved
+//! target passes fixed-path checks.
+
+use std::path::Path;
+
+use destructive_command_guard::packs::REGISTRY;
+use destructive_command_guard::{
+    config::Config, evaluator::evaluate_command_with_pack_order_at_path, load_default_allowlists,
+};
+
+fn evaluate_at(cmd: &str, cwd: &Path) -> destructive_command_guard::evaluator::EvaluationResult {
+    let config = Config::default();
+    let compiled_overrides = config.overrides.compile();
+    let allowlists = load_default_allowlists();
+    let enabled_packs = config.enabled_pack_ids();
+    let ordered_packs = REGISTRY.expand_enabled_ordered(&enabled_packs);
+    let keyword_index = REGISTRY.build_enabled_keyword_index(&ordered_packs);
+
+    evaluate_command_with_pack_order_at_path(
+        cmd,
+        &REGISTRY.collect_enabled_keywords(&enabled_packs),
+        &ordered_packs,
+        keyword_index.as_ref(),
+        &compiled_overrides,
+        &allowlists,
+        &config.heredoc_settings(),
+        Some(cwd),
+    )
+}
+
+fn allowed(cmd: &str, cwd: &Path) {
+    let result = evaluate_at(cmd, cwd);
+    assert!(
+        result.is_allowed(),
+        "expected a proven literal redirect target to be allowed: {cmd:?} -> {:?} {:?}",
+        result.decision,
+        result.pattern_info
+    );
+}
+
+fn denied(cmd: &str, cwd: &Path) {
+    let result = evaluate_at(cmd, cwd);
+    assert!(
+        result.is_denied(),
+        "expected an unresolved or unsafe redirect target to be denied: {cmd:?} -> {:?}",
+        result.decision
+    );
+}
+
+#[test]
+fn prior_single_literal_assignment_resolves_the_redirect_target() {
+    let cwd = tempfile::tempdir().unwrap();
+    std::fs::create_dir(cwd.path().join("logs")).unwrap();
+
+    allowed(
+        "log=/tmp/dcg-literal-assignment.log; : > \"$log\"",
+        cwd.path(),
+    );
+    allowed("log='logs/run-20260731.log'; : > \"${log}\"", cwd.path());
+    allowed(
+        "log=/tmp/dcg-run.log; : > \"$log\"; (echo ok) >\"$log\" 2>&1 &",
+        cwd.path(),
+    );
+}
+
+#[test]
+fn unresolved_or_mutated_assignment_remains_denied() {
+    let cwd = tempfile::tempdir().unwrap();
+
+    for command in [
+        ": > \"$log\"",
+        "log=$OTHER; : > \"$log\"",
+        "log=$(mktemp); : > \"$log\"",
+        "log=`mktemp`; : > \"$log\"",
+        "log=/tmp/first; log=/tmp/second; : > \"$log\"",
+        "log=/tmp/first; log+=-second; : > \"$log\"",
+        "log=/tmp/out; unset log; : > \"$log\"",
+        "log=/tmp/out; printf -v log /tmp/other; : > \"$log\"",
+        "log=/tmp/out; true; : > \"$log\"",
+        "log=/tmp/out; source ./mutator.sh; : > \"$log\"",
+        "log=/tmp/out; eval 'log=/tmp/other'; : > \"$log\"",
+        "log=/tmp/out; : > \"${log}.suffix\"",
+        "log=/tmp/out; : > \"$log\" > \"$OTHER\"",
+    ] {
+        denied(command, cwd.path());
+    }
+}
+
+#[test]
+fn sensitive_literal_assignment_remains_denied() {
+    let cwd = tempfile::tempdir().unwrap();
+
+    for command in [
+        "log=/etc/passwd; : > \"$log\"",
+        "log=/home/other/file; : > \"$log\"",
+        "log=~/file; : > \"$log\"",
+        "log='/var/lib/service/data'; : > \"$log\"",
+        "log=/var/tmp/evidence.log; : > \"$log\"",
+    ] {
+        denied(command, cwd.path());
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_and_non_regular_targets_remain_denied() {
+    use std::os::unix::fs::symlink;
+
+    let cwd = tempfile::tempdir().unwrap();
+    let regular = cwd.path().join("regular.log");
+    let link = cwd.path().join("linked.log");
+    let directory = cwd.path().join("directory.log");
+    let linked_parent = cwd.path().join("linked-parent");
+    std::fs::write(&regular, "evidence").unwrap();
+    symlink(&regular, &link).unwrap();
+    std::fs::create_dir(&directory).unwrap();
+    symlink(cwd.path(), &linked_parent).unwrap();
+
+    allowed(
+        &format!("log={}; : > \"$log\"", regular.display()),
+        cwd.path(),
+    );
+    denied(&format!("log={}; : > \"$log\"", link.display()), cwd.path());
+    denied(
+        &format!("log={}; : > \"$log\"", directory.display()),
+        cwd.path(),
+    );
+    denied(
+        &format!("log={}/out.log; : > \"$log\"", linked_parent.display()),
+        cwd.path(),
+    );
+}

--- a/tests/repro_redirect_literal_assignment.rs
+++ b/tests/repro_redirect_literal_assignment.rs
@@ -48,6 +48,7 @@ fn denied(cmd: &str, cwd: &Path) {
     );
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn prior_single_literal_assignment_resolves_the_redirect_target() {
     let cwd = tempfile::tempdir().unwrap();
@@ -102,7 +103,7 @@ fn sensitive_literal_assignment_remains_denied() {
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn symlink_and_non_regular_targets_remain_denied() {
     use std::os::unix::fs::symlink;


### PR DESCRIPTION
## Summary

- resolve a truncating redirect target only when it is an exact shell variable with one preceding literal assignment
- keep dynamic, mutated, sensitive, multi-target, symlink, wrong-owner, and non-regular targets denied
- permit the common run-log sequence with a no-op initializer and static FD duplication
- document the bounded proof and its TOCTOU limitation

## Safety boundary

This is not an allowlist. On Linux, the dynamic-path rule is skipped only after bounded POSIX proof and fixed-path checks. Other platforms retain the current fail-closed decision until they have an equally trustworthy effective-user identity source. Unknown shell state, arbitrary intervening commands, command substitution, variable concatenation, additional path redirects, sensitive roots, and unverifiable ownership all fail closed.

The shell still performs the eventual open, so preflight checks cannot eliminate TOCTOU. A private 0700 run directory remains preferable to a shared `/tmp` basename.

## Tests

- `cargo test --test repro_redirect_literal_assignment`
- `cargo test --test repro_redirect_quoted_data`
- `cargo test --test repro_redirection_bypass`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --all-targets`
- full `cargo test` with production Pi/DCG environment variables removed: pass
