### PR TITLE
fix(core.git): judge executable evidence on the basename, not the whole path (closes #360, #361)

### DIFF
--- a/src/packs/core/git.rs
+++ b/src/packs/core/git.rs
@@ -1515,23 +1515,51 @@ fn git_semantic_word_is_unbounded(word: &GitSemanticWord, dialect: ShellDialect)
             .all(String::is_empty)
 }
 
-fn git_semantic_executable_may_equal(
+/// The executable-*name* view of a word: the basename after the last path
+/// separator, with `dynamic` recomputed from that basename alone.
+///
+/// Only the basename names the program, so both questions a `core.git` gate
+/// asks — "may this name be `git`?" and "does this name carry literal
+/// evidence?" — are properties of the basename. Inheriting the whole word's
+/// `dynamic` flag answers them against a different string and fails in both
+/// directions: a wildcard *directory* leaves a fully literal `git` basename
+/// marked dynamic, and a wildcard *basename* lets the `/` separator count as
+/// the literal evidence that a pure expansion is supposed to lack.
+fn git_semantic_executable_basename(
     word: &GitSemanticWord,
     dialect: ShellDialect,
-    candidate: &str,
-) -> bool {
+) -> GitSemanticWord {
     let decoded = if dialect == ShellDialect::Cmd {
         word.decoded.trim_start_matches('@')
     } else {
         &word.decoded
     };
     let basename = decoded.rsplit(['/', '\\']).next().unwrap_or(decoded);
-    let word = GitSemanticWord {
+    // More than one fragment means an expansion was found inside the basename
+    // itself. A single fragment is wholly literal text, whatever the rest of
+    // the path did.
+    let dynamic = word.dynamic && git_dynamic_fragments(basename, dialect).len() > 1;
+    GitSemanticWord {
         decoded: basename.to_string(),
-        dynamic: word.dynamic,
+        dynamic,
         may_split: word.may_split,
-    };
+    }
+}
+
+fn git_semantic_executable_may_equal(
+    word: &GitSemanticWord,
+    dialect: ShellDialect,
+    candidate: &str,
+) -> bool {
+    let word = git_semantic_executable_basename(word, dialect);
     git_symbolic_word_may_equal(&word, dialect, candidate, true)
+}
+
+/// [`git_semantic_word_is_unbounded`] judged on the executable name (#281). A
+/// path separator is not evidence about the name that follows it, so `/*` is
+/// exactly as unbounded as the bare `*` that already supplies no Git evidence.
+fn git_semantic_executable_is_unbounded(word: &GitSemanticWord, dialect: ShellDialect) -> bool {
+    git_semantic_word_is_unbounded(&git_semantic_executable_basename(word, dialect), dialect)
 }
 
 fn decode_git_semantic_words(command: &str, dialect: ShellDialect) -> Option<DecodedGitWords> {
@@ -3562,7 +3590,7 @@ fn dynamic_git_branch_may_mutate(command: &str, dialect: ShellDialect) -> bool {
     // two unknowns are not evidence. Literal branch syntax after it (e.g.
     // `$(producer) branch -d feature`) still fails closed below.
     let executable_unbounded =
-        !powershell_expression && git_semantic_word_is_unbounded(executable, dialect);
+        !powershell_expression && git_semantic_executable_is_unbounded(executable, dialect);
     let dashed_branch = !powershell_expression
         && !executable_unbounded
         && (git_semantic_executable_may_equal(executable, dialect, "git-branch")
@@ -3578,6 +3606,22 @@ fn dynamic_git_branch_may_mutate(command: &str, dialect: ShellDialect) -> bool {
     index += 1;
     if dashed_branch {
         return semantic_branch_argv_may_mutate(&words[index..], dialect);
+    }
+
+    // #281, applied to the whole remaining argv rather than only to the tail
+    // that follows a dynamic word. When the executable name proved nothing,
+    // no word here may stand in for the literal `branch` subcommand — but a
+    // literal deletion/force flag is still evidence in plain sight, and it can
+    // sit in the very first argv slot when the unbounded executable is a glob
+    // (`/* -D main`) rather than an expansion (`$g $sub -D main`).
+    if executable_unbounded
+        && literal_branch_tokens_prove_mutation(
+            words[index..]
+                .iter()
+                .map(|word| (!word.dynamic).then_some(word.decoded.as_str())),
+        )
+    {
+        return true;
     }
 
     loop {
@@ -3690,7 +3734,15 @@ fn dynamic_git_branch_may_mutate(command: &str, dialect: ShellDialect) -> bool {
             index += 1;
             continue;
         }
-        // An unresolved command may be a persistent alias for `branch`.
+        // An unresolved command may be a persistent alias for `branch` — but
+        // only once something has established that Git is running at all.
+        // #281: when the executable name was itself unbounded, an unknown
+        // subcommand is a second unknown, and two unknowns are not evidence.
+        // The literal-flag scan above already kept any deletion in plain
+        // sight, so there is nothing further to prove here.
+        if executable_unbounded {
+            return false;
+        }
         return semantic_branch_argv_may_mutate(&words[index + 1..], dialect);
     }
 }
@@ -5564,6 +5616,129 @@ mod tests {
                             | BranchCommandDecision::DestructiveDynamic
                     ),
                     "no branch mutation evidence, must not deny: {command} ({dialect:?}) -> {decision:?}"
+                );
+            }
+        }
+    }
+
+    // =========================================================================
+    // A pure-wildcard basename is an unbounded executable name (#360, #361)
+    // =========================================================================
+
+    /// A path whose basename is *only* glob metacharacters names nothing. It
+    /// may still expand to `git`, exactly as the bare `*` that #281 already
+    /// treats as no evidence, so the two spellings must agree: a second
+    /// wildcard word cannot serve as both the `branch` subcommand and the
+    /// dynamic token the rule requires.
+    ///
+    /// The reported symptom was that an ordinary C/JSDoc block comment reaching
+    /// a shell was denied as a destructive Git invocation (#360).
+    #[test]
+    fn pure_wildcard_basename_supplies_no_git_evidence_360() {
+        for command in [
+            // The four-character minimal reproducer.
+            "/* *",
+            // The C block-comment pair, and the real JSDoc line that was denied.
+            "/* */",
+            "/** Default language for new articles */",
+            // Every pure-metacharacter basename spelling.
+            "/? *",
+            "/?? *",
+            "/[a-z]* *",
+            "./* *",
+            "bin/* *",
+            // A wildcard word that "may equal" branch is still only a wildcard.
+            "/* b*",
+            // A dynamic expansion behind a path separator is no more bounded
+            // than the bare expansion: the `/` is not evidence about the name.
+            "dir/$X $sub",
+        ] {
+            for dialect in [ShellDialect::Unknown, ShellDialect::Posix] {
+                let decision = branch_command_decision_in_dialect(command, dialect);
+                assert!(
+                    !matches!(
+                        decision,
+                        BranchCommandDecision::Destructive
+                            | BranchCommandDecision::DestructiveDynamic
+                    ),
+                    "pure-wildcard basename supplies no git evidence: {command} ({dialect:?}) -> {decision:?}"
+                );
+            }
+        }
+    }
+
+    /// The reported command in full: a `python3` heredoc that rewrites source
+    /// files and contains neither `git` nor `branch`. The JSDoc line inside the
+    /// body is what manufactured the match (#360).
+    #[test]
+    fn python_heredoc_rewriting_source_is_not_a_git_branch_360() {
+        let command = concat!(
+            "cd /tmp/project && python3 - <<'PY'\n",
+            "edits = [\n",
+            "    ('src/config.ts', '/** Default language for new articles */', '/** Default locale */'),\n",
+            "]\n",
+            "for p, old, new in edits:\n",
+            "    s = open(p).read()\n",
+            "    open(p, 'w').write(s.replace(old, new))\n",
+            "PY",
+        );
+        for dialect in [ShellDialect::Unknown, ShellDialect::Posix] {
+            let decision = branch_command_decision_in_dialect(command, dialect);
+            assert!(
+                !matches!(
+                    decision,
+                    BranchCommandDecision::Destructive | BranchCommandDecision::DestructiveDynamic
+                ),
+                "python heredoc rewriting source is not a git branch command: ({dialect:?}) -> {decision:?}"
+            );
+        }
+    }
+
+    /// The mirror defect (#361). A wildcard in a *directory* component leaves a
+    /// fully literal `git` basename, which unambiguously names Git — treating
+    /// that name as dynamic let a real destructive invocation evade the entire
+    /// `core.git` pack while the literal-path spelling was denied.
+    #[test]
+    fn wildcard_directory_with_literal_git_basename_stays_fail_closed_361() {
+        for command in [
+            "/usr/*/git branch -D main",
+            "/usr/*/git branch $name",
+            "/*/bin/git branch $name",
+            "/usr/b?n/git branch -D main",
+            "$HOME/*/git branch -D main",
+        ] {
+            for dialect in [ShellDialect::Unknown, ShellDialect::Posix] {
+                let decision = branch_command_decision_in_dialect(command, dialect);
+                assert!(
+                    matches!(
+                        decision,
+                        BranchCommandDecision::Destructive
+                            | BranchCommandDecision::DestructiveDynamic
+                    ),
+                    "literal git basename must stay fail-closed: {command} ({dialect:?}) -> {decision:?}"
+                );
+            }
+        }
+    }
+
+    /// The allow above must not become a bypass. A literal deletion/force flag
+    /// after a wildcard executable is evidence in plain sight, exactly as it is
+    /// after the `$g $sub` spelling that #281 already keeps fail-closed.
+    #[test]
+    fn literal_mutation_after_wildcard_executable_stays_fail_closed_360() {
+        for command in [
+            "/* -D main",
+            "/* -d feature",
+            "/* --delete --force main",
+            "/* -M old new",
+            "bin/* -D main",
+            "/* $sub -D main",
+        ] {
+            for dialect in [ShellDialect::Unknown, ShellDialect::Posix] {
+                assert_eq!(
+                    branch_command_decision_in_dialect(command, dialect),
+                    BranchCommandDecision::DestructiveDynamic,
+                    "literal mutation evidence must stay denied: {command} ({dialect:?})"
                 );
             }
         }

--- a/tests/corpus/bypass_attempts/obfuscation.toml
+++ b/tests/corpus/bypass_attempts/obfuscation.toml
@@ -88,3 +88,21 @@ expected = "deny"
 description = "TMPDIR default expansion is denied because a nonempty unsafe value wins"
 command = "rm -rf ${TMPDIR:-/tmp}/build"
 expected = "deny"
+
+[[case]]
+description = "wildcard directory with a literal git basename (#361)"
+command = "/usr/*/git branch -D main"
+expected = "deny"
+rule_id = "core.git:branch-dynamic-token"
+
+[[case]]
+description = "wildcard root directory with a literal git basename (#361)"
+command = "/*/bin/git branch $name"
+expected = "deny"
+rule_id = "core.git:branch-dynamic-token"
+
+[[case]]
+description = "literal branch deletion after a wildcard executable (#360)"
+command = "/* -D main"
+expected = "deny"
+rule_id = "core.git:branch-dynamic-token"

--- a/tests/corpus/false_positives/git_safe.toml
+++ b/tests/corpus/false_positives/git_safe.toml
@@ -181,3 +181,18 @@ expected = "allow"
 description = "literal command substitution output passed to echo is inert data"
 command = "echo \"$(printf 'git reset --hard')\""
 expected = "allow"
+
+[[case]]
+description = "a path whose basename is only glob metacharacters names nothing (#360)"
+command = "/* *"
+expected = "allow"
+
+[[case]]
+description = "a C block comment reaching the shell is not a git branch command (#360)"
+command = "/** Default language for new articles */"
+expected = "allow"
+
+[[case]]
+description = "a wildcard word cannot stand in for the branch subcommand (#360)"
+command = "/* b*"
+expected = "allow"


### PR DESCRIPTION
Fixes #360 (false positive) and #361 (the mirror false negative). One root cause, one fix.

## The defect

`core.git` asks two questions about a command's executable word:

1. *May this name be `git`?* — answered against the **basename** (`git_semantic_executable_may_equal`).
2. *Does this name carry literal bytes, or is it an unbounded expansion that proves nothing (#281)?* — answered against the **whole word** (`git_semantic_word_is_unbounded`).

Because the two questions were asked of different strings, the pack failed in both directions.

**False positive (#360).** A path whose basename is *only* glob metacharacters — `/*`, `./*`, `/??`, `/[a-z]*` — glob-matches `git`, so question 1 opened the gate. But the `/` separator counted as the literal byte that keeps a word from being unbounded, so question 2 said "bounded" and #281's two-unknowns rule never applied. A later wildcard word then did double duty as the `branch` subcommand *and* as the dynamic token the rule requires.

The minimal reproducer is four characters — an ordinary C block comment:

```
dcg explain --dialect posix '/* *'      # DENY core.git:branch-dynamic-token
```

The originally reported command was a `python3` heredoc rewriting a TypeScript file, containing no `git` and no `branch` anywhere. The trigger was one JSDoc line in the body:

```
  /** Default language for new articles */
```

This is the common case for an agent editing source: any block comment that reaches a shell in a multi-line command or an interpreter-stdin heredoc is a candidate. The denial then explained at length how to quote a Git branch name, which is not remotely what the command was doing.

**False negative (#361).** The same logic inverted for a wildcard in a *directory* component. `/usr/*/git` has a fully literal `git` basename, but the basename word inherited the whole path's `dynamic` flag, so the fragment matcher was asked to fit `git` between a first and last fragment that were both the entire string — impossible — and the name failed to match at all. So `/usr/*/git branch -D main` evaded the **entire** `core.git` pack, while the literal `/usr/bin/git` spelling was correctly denied.

## The fix

Compute the executable-name view once, in `git_semantic_executable_basename`: take the basename, then **recompute `dynamic` from that basename alone**. Both questions are now asked of the string that actually names the program.

- `/*` becomes exactly as unbounded as the bare `*` that the pack already treats as no evidence — so the two spellings finally agree.
- A literal `git` basename is literal, however wild the directories above it are.

Note the wildcard gate itself is *not* weakened: `/*` may still expand to `git`, and is still treated that way. What changed is that it no longer counts as *evidence* that Git is running.

Two consequences follow from #281's own policy, and both are wired up so the allow cannot become a bypass:

- **A literal deletion/force flag in the remaining argv is still evidence in plain sight.** With a glob executable it can sit in the very first argv slot (`/* -D main`), where the existing check — which only ran after a dynamic word, as in the `$g $sub -D main` shape — did not reach it.
- **An unresolved literal token is no longer assumed to be a persistent `branch` alias when the executable name was itself unbounded.** Two unknowns are not evidence. This is what kept the reported JSDoc line denied even once the wildcard was correctly classified.

## Verification

Against the 33-case corpus from the issue reports:

| group | before | after |
|---|---|---|
| FP — must allow | 6/16 | **15/16** |
| KNOWN-FN — bypasses that must deny | 0/4 | **4/4** |
| PROTECTION — must deny | 10/10 | 10/10 |
| SAFE — documented safe spellings | 3/3 | 3/3 |

The one remaining FP is `/* -D main`, **denied by design**: a glob in command position carrying a literal `-D` really could be a branch deletion, and per #281 that literal flag is evidence on its own merits.

Every genuine protection still blocks — dynamic branch names via variables, command substitution and backticks; `-D`, `-d`, `-M`; absolute-path git; a real `git branch` after a heredoc — and the documented safe spellings (quoted branch name, `--` guard, plain `git branch`) stay allowed. One protection case improved its attribution from `branch-dynamic-token` to the more precise `branch-force-delete`.

Added as regression coverage:

- Four unit tests in `src/packs/core/git.rs`, including the exact `python3` heredoc shape from the report, the pure-metacharacter basename spellings, the #361 wildcard-directory bypasses, and the literal-mutation-after-wildcard cases that must keep denying.
- Three cases in `tests/corpus/false_positives/git_safe.toml` (the corpus previously had no glob or comment case) and three in `tests/corpus/bypass_attempts/obfuscation.toml`.

Full suite passes: ~4300 tests, 0 failures. `cargo fmt --check` and `cargo clippy --all-targets` are clean.

By Merlin ([rbeckner.com](https://rbeckner.com)) and his AI agent (Claude Code, Fable 5, thinking on: default).
