### PR TITLE
fix(core.git): a quoted delimiter into a non-shell interpreter is not dynamic-branch evidence (#357)

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -23419,6 +23419,49 @@ pub(crate) fn command_invokes_declared_executable(command: &str, executables: &[
     })
 }
 
+/// `core.git:branch-dynamic-token` is the one `core.git` rule whose entire
+/// evidence is a *shell expansion*: an unquoted `$`/backtick reaches git's argv,
+/// the shell expands and field-splits it, and the result can inject `-D`/`-f`/
+/// `-M`/`-C`. Every other `core.git` rule — `branch-force-delete`, `reset-hard`,
+/// … — judges literal tokens.
+///
+/// A heredoc with a **quoted** delimiter received by a proven **non-shell**
+/// interpreter (`python3 - <<'PY'`, `node - <<'JS'`, …) is precisely the case
+/// where that evidence does not exist: POSIX guarantees the outer shell performs
+/// no expansion, and the receiver does not run its stdin as shell. The bytes
+/// `git branch $name` in such a body are inert text to every shell that runs
+/// this command line — the same status they already have in the inline spelling
+/// `python3 -c 'git branch $name'`, which dcg allows today. Denying one and
+/// allowing the other is an inconsistency in the delivery mechanism, not a
+/// security boundary (#357, and the #136/#278 heredoc-body class).
+///
+/// This withdraws *only* that one piece of evidence. The body is NOT masked: it
+/// keeps flowing through the conservative raw-shell scan, so `rm -rf /etc`,
+/// `git branch -D main`, and `git reset --hard` inside the very same body still
+/// deny, and the #136-revert posture is untouched. A shell receiver
+/// (`bash <<'EOF'`) or an unquoted delimiter (`<<EOF`) keeps the deny, because in
+/// both of those a shell really does expand the token.
+///
+/// Fail-safe: any coordinate ambiguity returns `false`. The slice maps onto
+/// `original_command` byte-for-byte only when normalization was the identity, the
+/// same guard the git semantic parser above uses for `git_semantic_command`.
+fn dynamic_branch_evidence_is_outer_shell_inert(
+    branch_decision: Option<crate::packs::core::git::BranchCommandDecision>,
+    original_command: &str,
+    normalized_offset: Option<usize>,
+    slice_offset: usize,
+    slice_len: usize,
+) -> bool {
+    matches!(
+        branch_decision,
+        Some(crate::packs::core::git::BranchCommandDecision::DestructiveDynamic)
+    ) && normalized_offset == Some(0)
+        && crate::heredoc::range_is_inert_interpreter_stdin(
+            original_command,
+            &(slice_offset..slice_offset.saturating_add(slice_len)),
+        )
+}
+
 fn evaluate_pack_destructive_patterns(
     pack_id: &str,
     pack: &crate::packs::Pack,
@@ -23469,6 +23512,12 @@ fn evaluate_pack_destructive_patterns(
     if matches!(
         branch_decision,
         Some(crate::packs::core::git::BranchCommandDecision::NonDestructive)
+    ) || dynamic_branch_evidence_is_outer_shell_inert(
+        branch_decision,
+        original_command,
+        normalized_offset,
+        slice_offset,
+        command_slice.len(),
     ) {
         return None;
     }
@@ -37548,6 +37597,165 @@ mod tests {
                     .is_allowed(),
                 "{dialect:?} must be unaffected by the unknown-dialect fan-out"
             );
+        }
+    }
+
+    // ========================================================================
+    // A quoted delimiter into a non-shell interpreter withdraws the
+    // dynamic-branch evidence, and nothing else (#357, #136/#278 class)
+    // ========================================================================
+
+    mod inert_quoted_interpreter_heredoc {
+        use super::{ShellDialect, evaluate_with_pack_ids_in_dialect};
+
+        fn denied(command: &str) -> bool {
+            [ShellDialect::Posix, ShellDialect::Unknown]
+                .into_iter()
+                .any(|dialect| {
+                    evaluate_with_pack_ids_in_dialect(
+                        command,
+                        &["core.git", "core.filesystem"],
+                        dialect,
+                    )
+                    .is_denied()
+                })
+        }
+
+        fn denying_rule(command: &str) -> Option<String> {
+            evaluate_with_pack_ids_in_dialect(
+                command,
+                &["core.git", "core.filesystem"],
+                ShellDialect::Posix,
+            )
+            .pattern_info
+            .as_ref()
+            .and_then(|info| info.pattern_name.as_deref())
+            .map(str::to_string)
+        }
+
+        /// `branch-dynamic-token`'s entire finding is "an unquoted `$`/backtick
+        /// reaches git's argv, where the shell expands and field-splits it into
+        /// something that may be `-D`". A quoted delimiter means the outer shell
+        /// expands nothing, and a non-shell interpreter does not run its stdin as
+        /// shell — so no shell ever sees that expansion and the evidence is
+        /// absent by construction.
+        ///
+        /// dcg already reaches this conclusion for the inline spelling:
+        /// `python3 -c 'git branch $name'` is allowed today. Denying the heredoc
+        /// spelling of the identical bytes to the identical receiver made the
+        /// verdict a property of the delivery mechanism (#357).
+        #[test]
+        fn quoted_delimiter_to_a_non_shell_interpreter_is_not_dynamic_branch_evidence_357() {
+            for command in [
+                "python3 - <<'EOF'\ngit branch $name\nEOF",
+                "python3 <<'PY'\ngit branch $(cat name)\nPY",
+                "python3 - <<'PY'\ngit branch `cat name`\nPY",
+                "/usr/bin/python3 - <<'PY'\ngit branch $name\nPY",
+                "node - <<'JS'\ngit branch $name\nJS",
+                "ruby <<'RB'\ngit branch $name\nRB",
+                "perl <<'PL'\ngit branch $name\nPL",
+                "php <<'PHP'\ngit branch $name\nPHP",
+                "deno <<'TS'\ngit branch $name\nTS",
+                // The reported shape: an editing heredoc whose body merely
+                // contains text that reads as a git invocation.
+                "cd /tmp/project && python3 - <<'PY'\ns = open('a.ts').read()\n# git branch $name\nopen('a.ts', 'w').write(s)\nPY",
+            ] {
+                assert!(
+                    !denied(command),
+                    "quoted delimiter + non-shell interpreter is not dynamic-branch evidence: {command:?}"
+                );
+            }
+        }
+
+        /// The two conditions are load-bearing, and each alone must keep the
+        /// deny. An unquoted delimiter really is expanded by the outer shell
+        /// before the receiver ever runs; a shell receiver really does expand
+        /// the body when it executes it.
+        #[test]
+        fn shell_receivers_and_unquoted_delimiters_keep_the_dynamic_branch_deny_357() {
+            for command in [
+                // Unquoted delimiter: the OUTER shell expands the body.
+                "python3 - <<EOF\ngit branch $name\nEOF",
+                "node - <<JS\ngit branch $name\nJS",
+                // Shell receivers: the body is shell and really is executed.
+                "bash <<'EOF'\ngit branch $name\nEOF",
+                "sh <<'EOF'\ngit branch $name\nEOF",
+                "zsh <<'EOF'\ngit branch $name\nEOF",
+                "fish <<'EOF'\ngit branch $name\nEOF",
+                // `dash`/`ksh` are not modeled as a language, so they are
+                // Unknown — which must stay conservative, never "not a shell".
+                "dash <<'EOF'\ngit branch $name\nEOF",
+                "ksh <<'EOF'\ngit branch $name\nEOF",
+                // Unmodeled receivers keep the conservative treatment.
+                "jq -f - <<'EOF'\ngit branch $name\nEOF",
+                "sqlite3 db <<'EOF'\ngit branch $name\nEOF",
+                "somebin - <<'EOF'\ngit branch $name\nEOF",
+                // A real invocation AFTER the terminator is outside the body.
+                "python3 - <<'EOF'\nx = 1\nEOF\ngit branch $name",
+                // Text that merely resembles a heredoc operator cannot declare
+                // a span of the command inert.
+                "echo 'python3 - <<EOF'; git branch $name",
+            ] {
+                assert!(
+                    denied(command),
+                    "outer-shell expansion is still reachable here: {command:?}"
+                );
+            }
+        }
+
+        /// The body is NOT masked. Only the one expansion-shaped finding is
+        /// withdrawn, so every rule that judges a literal token still sees the
+        /// body and still fires — which is exactly what the #136/#278 revert
+        /// requires of the conservative raw-shell scan.
+        #[test]
+        fn literal_destructive_evidence_in_the_same_body_still_denies_136() {
+            for (command, rule) in [
+                (
+                    "python3 - <<'PY'\ngit branch -D main\nPY",
+                    "branch-force-delete",
+                ),
+                (
+                    "python3 - <<'PY'\ngit branch -M main other\nPY",
+                    "branch-force-delete",
+                ),
+                ("python3 - <<'PY'\ngit reset --hard\nPY", "reset-hard"),
+                ("python3 - <<'PY'\nrm -rf /etc\nPY", "rm-rf-root-home"),
+                (
+                    "python3 - <<'PY'\nprint(\"rm -rf $HOME\")\nPY",
+                    "rm-rf-root-home",
+                ),
+            ] {
+                assert_eq!(
+                    denying_rule(command).as_deref(),
+                    Some(rule),
+                    "literal destructive evidence must survive: {command:?}"
+                );
+            }
+        }
+
+        /// A wrapper has materially different lookup and execution rules and can
+        /// itself be a function, alias, or PATH-selected executable, so proving
+        /// only its final argument is not a proof about the receiver. And a
+        /// receiver name that visible shell state may have rebound is no proof
+        /// either. Both fail closed.
+        #[test]
+        fn wrapper_and_rebindable_receivers_stay_conservative_357() {
+            for command in [
+                "env python3 - <<'PY'\ngit branch $name\nPY",
+                "sudo python3 - <<'PY'\ngit branch $name\nPY",
+                "command python3 - <<'PY'\ngit branch $name\nPY",
+                "nohup python3 - <<'PY'\ngit branch $name\nPY",
+                "python3() { bash -s; }\npython3 - <<'PY'\ngit branch $name\nPY",
+                "alias python3='bash -s'\npython3 - <<'PY'\ngit branch $name\nPY",
+                "eval 'python3(){ bash -s; }'; python3 - <<'PY'\ngit branch $name\nPY",
+                "./python3 - <<'PY'\ngit branch $name\nPY",
+                "/tmp/python3 - <<'PY'\ngit branch $name\nPY",
+            ] {
+                assert!(
+                    denied(command),
+                    "an unproven receiver must keep the conservative deny: {command:?}"
+                );
+            }
         }
     }
 }

--- a/src/heredoc.rs
+++ b/src/heredoc.rs
@@ -2985,6 +2985,89 @@ pub fn is_interpreter_source_heredoc_command(cmd: &str) -> bool {
     }
 }
 
+/// Check whether a heredoc target provably does NOT run its stdin as shell.
+///
+/// True for a concrete non-shell interpreter reading its program from the body
+/// (`python3 -`, `node -`, `ruby`, `perl`, `php`, `deno`, `bun`, `go`).
+///
+/// Deliberately excludes [`ScriptLanguage::Bash`] — which covers `sh`, `bash`,
+/// `zsh`, `fish`, and PowerShell, all of which execute their stdin as shell —
+/// and [`ScriptLanguage::Unknown`], because an unrecognized name may well BE a
+/// shell (`dash`, `ksh`, `busybox sh`, a wrapper script). Returning `false` is
+/// the fail-safe in both directions: the body keeps its conservative treatment.
+///
+/// This says nothing about whether the body is safe. It is a statement about the
+/// **outer** shell only, and its sole use is [`range_is_inert_interpreter_stdin`].
+#[must_use]
+pub fn is_non_shell_interpreter_stdin_command(cmd: &str) -> bool {
+    let cmd_name = cmd.rsplit(['/', '\\']).next().unwrap_or(cmd);
+    matches!(
+        ScriptLanguage::from_command(cmd_name),
+        ScriptLanguage::Python
+            | ScriptLanguage::JavaScript
+            | ScriptLanguage::TypeScript
+            | ScriptLanguage::Ruby
+            | ScriptLanguage::Perl
+            | ScriptLanguage::Php
+            | ScriptLanguage::Go
+    )
+}
+
+/// True when `range` lies entirely inside a heredoc body that both
+///
+/// 1. has a **quoted** delimiter (`<<'PY'`, `<<"PY"`, `<<\PY`), so POSIX
+///    guarantees the outer shell performs *no* expansion on the body, and
+/// 2. is received by a proven non-shell interpreter
+///    ([`is_non_shell_interpreter_stdin_command`]) that the visible shell state
+///    cannot have rebound ([`stdin_data_sink_may_be_overridden`]).
+///
+/// Under those two conditions the outer shell neither expands nor executes those
+/// bytes: they are handed to the interpreter verbatim. That is the *entire*
+/// claim. The body is still interpreter source that may reach an execution sink,
+/// so it deliberately keeps flowing through the conservative raw-shell scan
+/// (#136 / #278) — nothing here masks it.
+///
+/// The single legitimate use is to withdraw evidence that is *defined* as an
+/// outer-shell expansion (`core.git:branch-dynamic-token`, whose whole finding is
+/// "an unquoted `$`/backtick reaches git's argv and can field-split into `-D`").
+/// Rules that judge literal tokens — `branch-force-delete`, `reset-hard`,
+/// `rm -rf /`, … — must never consult this, and do not.
+///
+/// Fail-safe in every ambiguous direction: an unquoted delimiter, an unparsable
+/// command, a here-string, an unknown or wrapper-obscured target, or a range that
+/// straddles the body boundary all return `false`.
+#[must_use]
+pub(crate) fn range_is_inert_interpreter_stdin(command: &str, range: &Range<usize>) -> bool {
+    if range.start >= range.end || !command.contains("<<") {
+        return false;
+    }
+    // Only AST-proven heredoc operators count. Raw `<<` text inside quotes or a
+    // comment must never be able to declare a span of the command inert.
+    let Some(heredocs) = active_heredocs(command) else {
+        return false;
+    };
+    heredocs.iter().any(|heredoc| {
+        let ActiveHeredocBody::Heredoc {
+            body_start,
+            body_end,
+            delimiter_quoted,
+        } = heredoc.body
+        else {
+            return false;
+        };
+        if !delimiter_quoted || range.start < body_start || range.end > body_end {
+            return false;
+        }
+        let Some(target) = extract_heredoc_target_command(command, heredoc.operator_start) else {
+            return false;
+        };
+        if stdin_data_sink_may_be_overridden(command, heredoc.operator_start, &target) {
+            return false;
+        }
+        is_non_shell_interpreter_stdin_command(&target)
+    })
+}
+
 /// Check whether the command owning the heredoc at `heredoc_start` is a `git`
 /// built-in invocation that reads the heredoc body as DATA from stdin — a
 /// commit/tag/note *message* (`-F -`, `-F-`, `--file=-`, `--file -`) or the
@@ -6948,6 +7031,176 @@ EOF";
                 !mask_non_expanding_data_heredocs(command).contains("rm -r ./tree"),
                 "literal mutator words must not cause an obvious masking false positive: {command:?}"
             );
+        }
+    }
+
+    // ========================================================================
+    // Inert interpreter stdin: quoted delimiter + proven non-shell receiver
+    // ========================================================================
+
+    mod inert_interpreter_stdin {
+        use super::*;
+
+        /// Ask the predicate about the span of `needle` inside `command`.
+        fn needle_is_inert(command: &str, needle: &str) -> bool {
+            let start = command
+                .find(needle)
+                .unwrap_or_else(|| panic!("{needle:?} not present in {command:?}"));
+            range_is_inert_interpreter_stdin(command, &(start..start + needle.len()))
+        }
+
+        #[test]
+        fn quoted_delimiter_to_a_modeled_non_shell_interpreter_is_inert() {
+            for command in [
+                "python3 - <<'PY'\ngit branch $name\nPY",
+                "python3 - <<\"PY\"\ngit branch $name\nPY",
+                "/usr/bin/python3 - <<'PY'\ngit branch $name\nPY",
+                "node - <<'JS'\ngit branch $name\nJS",
+                "ruby <<'RB'\ngit branch $name\nRB",
+                "perl <<'PL'\ngit branch $name\nPL",
+                "php <<'PHP'\ngit branch $name\nPHP",
+                "bun <<'TS'\ngit branch $name\nTS",
+                "cd /tmp && python3 - <<'PY'\ngit branch $name\nPY",
+            ] {
+                assert!(
+                    needle_is_inert(command, "git branch $name"),
+                    "the outer shell expands nothing here: {command:?}"
+                );
+            }
+        }
+
+        /// Both conditions are load-bearing. An unquoted delimiter is expanded by
+        /// the outer shell before the receiver runs; a shell receiver expands the
+        /// body when it executes it. `dash`/`ksh` are unmodeled and therefore
+        /// Unknown, which must never be read as "not a shell".
+        #[test]
+        fn expanding_delimiters_and_shell_receivers_are_never_inert() {
+            for command in [
+                "python3 - <<PY\ngit branch $name\nPY",
+                "node - <<JS\ngit branch $name\nJS",
+                "bash <<'EOF'\ngit branch $name\nEOF",
+                "sh <<'EOF'\ngit branch $name\nEOF",
+                "zsh <<'EOF'\ngit branch $name\nEOF",
+                "fish <<'EOF'\ngit branch $name\nEOF",
+                "pwsh <<'EOF'\ngit branch $name\nEOF",
+                "dash <<'EOF'\ngit branch $name\nEOF",
+                "ksh <<'EOF'\ngit branch $name\nEOF",
+                "jq -f - <<'EOF'\ngit branch $name\nEOF",
+                "sqlite3 db <<'EOF'\ngit branch $name\nEOF",
+                "somebin - <<'EOF'\ngit branch $name\nEOF",
+                // A data sink is a different (already-masked) case, and this
+                // predicate deliberately does not claim it.
+                "cat <<'EOF'\ngit branch $name\nEOF",
+                // Pre-existing, unrelated: `extract_heredoc_target_resolution`
+                // reads a dotted name as a filename argument, so a versioned
+                // interpreter resolves to no target at all. That fails closed
+                // here, which is the correct direction; widening target
+                // resolution is a separate change.
+                "python3.11 - <<'PY'\ngit branch $name\nPY",
+            ] {
+                assert!(
+                    !needle_is_inert(command, "git branch $name"),
+                    "a shell may still expand this: {command:?}"
+                );
+            }
+        }
+
+        /// A wrapper resolves its own target under different rules, and a bare
+        /// receiver name that visible shell state may have rebound proves
+        /// nothing. Both fail closed, as the data-sink masking already does.
+        #[test]
+        fn wrapper_and_rebindable_receivers_are_never_inert() {
+            for command in [
+                "env python3 - <<'PY'\ngit branch $name\nPY",
+                "sudo python3 - <<'PY'\ngit branch $name\nPY",
+                "command python3 - <<'PY'\ngit branch $name\nPY",
+                "builtin python3 - <<'PY'\ngit branch $name\nPY",
+                "nohup python3 - <<'PY'\ngit branch $name\nPY",
+                "python3() { bash -s; }\npython3 - <<'PY'\ngit branch $name\nPY",
+                "alias python3='bash -s'\npython3 - <<'PY'\ngit branch $name\nPY",
+                "eval 'python3(){ bash -s; }'; python3 - <<'PY'\ngit branch $name\nPY",
+                "source ./bindings.sh; python3 - <<'PY'\ngit branch $name\nPY",
+                // An arbitrary path is not the OS interpreter it is named after.
+                "./python3 - <<'PY'\ngit branch $name\nPY",
+                "/tmp/python3 - <<'PY'\ngit branch $name\nPY",
+            ] {
+                assert!(
+                    !needle_is_inert(command, "git branch $name"),
+                    "an unproven receiver must fail closed: {command:?}"
+                );
+            }
+        }
+
+        /// The claim is scoped to the body's own bytes. Text before the operator,
+        /// after the terminator, or straddling either boundary is ordinary
+        /// command source that the shell really does expand and execute.
+        #[test]
+        fn only_the_body_itself_is_inert() {
+            let command = "python3 - <<'PY'\nx = 1\nPY\ngit branch $name";
+            assert!(
+                !needle_is_inert(command, "git branch $name"),
+                "a command after the terminator is not heredoc body"
+            );
+
+            let straddling = "python3 - <<'PY'\ngit branch $name\nPY";
+            let start = straddling.find("<<'PY'").expect("operator");
+            let end = straddling.find("\nPY").expect("terminator") + 3;
+            assert!(
+                !range_is_inert_interpreter_stdin(straddling, &(start..end)),
+                "a range that escapes the body must not be claimed inert"
+            );
+
+            // Quoted text that merely resembles a heredoc operator is data, not
+            // a syntax boundary, so it cannot declare later source inert.
+            let fake = "echo 'python3 - <<PY'\ngit branch $name";
+            assert!(!needle_is_inert(fake, "git branch $name"));
+
+            // Empty and inverted ranges are rejected outright.
+            assert!(!range_is_inert_interpreter_stdin(straddling, &(5..5)));
+        }
+
+        #[test]
+        fn shell_and_unknown_receiver_names_are_not_non_shell_interpreters() {
+            for shell in [
+                "sh",
+                "bash",
+                "zsh",
+                "fish",
+                "pwsh",
+                "powershell",
+                "powershell.exe",
+                "dash",
+                "ksh",
+                "jq",
+                "sqlite3",
+                "cat",
+                "somebin",
+            ] {
+                assert!(
+                    !is_non_shell_interpreter_stdin_command(shell),
+                    "{shell} must not be classified as a non-shell interpreter"
+                );
+            }
+            for interpreter in [
+                "python",
+                "python3",
+                "python3.11",
+                "python.exe",
+                "node",
+                "nodejs",
+                "ruby",
+                "irb",
+                "perl",
+                "php",
+                "deno",
+                "bun",
+                "go",
+            ] {
+                assert!(
+                    is_non_shell_interpreter_stdin_command(interpreter),
+                    "{interpreter} reads a non-shell program from stdin"
+                );
+            }
         }
     }
 }

--- a/tests/corpus/bypass_attempts/obfuscation.toml
+++ b/tests/corpus/bypass_attempts/obfuscation.toml
@@ -88,3 +88,21 @@ expected = "deny"
 description = "TMPDIR default expansion is denied because a nonempty unsafe value wins"
 command = "rm -rf ${TMPDIR:-/tmp}/build"
 expected = "deny"
+
+[[case]]
+description = "a wrapper is not a proof about the heredoc receiver (#357)"
+command = "env python3 - <<'PY'\ngit branch $name\nPY"
+expected = "deny"
+rule_id = "core.git:branch-dynamic-token"
+
+[[case]]
+description = "a rebound interpreter name may execute its stdin as shell (#357)"
+command = "alias python3='bash -s'\npython3 - <<'PY'\ngit branch $name\nPY"
+expected = "deny"
+rule_id = "core.git:branch-dynamic-token"
+
+[[case]]
+description = "a real invocation after the terminator is outside the body (#357)"
+command = "python3 - <<'PY'\nx = 1\nPY\ngit branch $name"
+expected = "deny"
+rule_id = "core.git:branch-dynamic-token"

--- a/tests/corpus/false_positives/heredoc_data.toml
+++ b/tests/corpus/false_positives/heredoc_data.toml
@@ -173,3 +173,37 @@ expected = "allow"
 description = "wc here-string is DATA"
 command = "wc -c <<<'rm -rf /'"
 expected = "allow"
+
+# ============================================================================
+# Quoted delimiter into a non-shell interpreter (#357)
+#
+# `<<'EOF'` suppresses every outer-shell expansion, and `python3`/`node`/`ruby`
+# do not run their stdin as shell. `branch-dynamic-token`'s entire finding is
+# "an unquoted expansion reaches git's argv", so no shell ever sees it. The
+# inline spelling `python3 -c 'git branch $name'` is already allowed; these are
+# the same bytes to the same receiver.
+#
+# The body is NOT masked: the literal cases in true_positives/git_destructive
+# and bypass_attempts/obfuscation prove it still flows through the raw-shell
+# scan (#136 / #278).
+# ============================================================================
+
+[[case]]
+description = "quoted python heredoc body is not dynamic-branch evidence (#357)"
+command = "python3 - <<'PY'\ngit branch $name\nPY"
+expected = "allow"
+
+[[case]]
+description = "quoted node heredoc body is not dynamic-branch evidence (#357)"
+command = "node - <<'JS'\ngit branch $(cat name)\nJS"
+expected = "allow"
+
+[[case]]
+description = "quoted ruby heredoc body is not dynamic-branch evidence (#357)"
+command = "ruby <<'RB'\ngit branch `cat name`\nRB"
+expected = "allow"
+
+[[case]]
+description = "an editing python heredoc whose body merely mentions a branch (#357)"
+command = "cd /tmp/project && python3 - <<'PY'\ns = open('a.ts').read()\n# git branch $name\nopen('a.ts', 'w').write(s)\nPY"
+expected = "allow"

--- a/tests/corpus/true_positives/git_destructive.toml
+++ b/tests/corpus/true_positives/git_destructive.toml
@@ -139,3 +139,27 @@ description = "git push -f (short form)"
 command = "git push -f origin main"
 expected = "deny"
 rule_id = "core.git:push-force-short"
+
+[[case]]
+description = "an unquoted delimiter is expanded by the outer shell (#357)"
+command = "python3 - <<PY\ngit branch $name\nPY"
+expected = "deny"
+rule_id = "core.git:branch-dynamic-token"
+
+[[case]]
+description = "a shell receiver executes its quoted heredoc body (#357)"
+command = "bash <<'EOF'\ngit branch $name\nEOF"
+expected = "deny"
+rule_id = "core.git:branch-dynamic-token"
+
+[[case]]
+description = "an unmodeled receiver keeps the conservative deny (#357)"
+command = "dash <<'EOF'\ngit branch $name\nEOF"
+expected = "deny"
+rule_id = "core.git:branch-dynamic-token"
+
+[[case]]
+description = "a literal branch deletion in a quoted interpreter body still denies (#357)"
+command = "python3 - <<'PY'\ngit branch -D main\nPY"
+expected = "deny"
+rule_id = "core.git:branch-force-delete"


### PR DESCRIPTION
Fixes the interpreter-stdin half of #357.

## The inconsistency

`core.git:branch-dynamic-token` is the one `core.git` rule whose entire finding is a **shell expansion**: an unquoted `$`/backtick reaches git's argv, the shell expands and field-splits it, and the result can inject `-D`, `-f`, `-M`, or `-C`. Every other rule in the pack judges literal tokens.

A heredoc with a **quoted** delimiter received by a proven **non-shell** interpreter is precisely the case where that evidence does not exist. POSIX guarantees `<<'PY'` suppresses every expansion in the outer shell, and `python3`/`node`/`ruby` do not run their stdin as shell — so no shell ever expands the token. dcg already reaches that conclusion for the inline spelling:

```
python3 -c 'git branch $name'        # ALLOW  on main
python3 - <<'PY'                     # DENY   on main
git branch $name
PY
```

Identical bytes, identical receiver, opposite verdicts. Only the delivery mechanism differs, which makes the verdict a property of the mechanism rather than of what any shell will actually do. In practice this fires on ordinary agent work: any `python3 - <<'PY' … PY` that edits a file whose contents happen to read as a git invocation.

## What this changes, and what it deliberately does not

It withdraws that **one** piece of evidence. The body is **not** masked.

This is explicitly *not* a re-litigation of #136 / #278. The conservative raw-shell scan those reverts rely on keeps running over the interpreter body, and the corpus now pins it — inside the very same quoted `python3` heredoc, all of these still deny:

| in a quoted `python3` body | verdict |
|---|---|
| `rm -rf /etc` | deny `core.filesystem:rm-rf-root-home` |
| `print("rm -rf $HOME")` | deny `core.filesystem:rm-rf-root-home` |
| `git branch -D main` | deny `core.git:branch-force-delete` |
| `git branch -M main other` | deny `core.git:branch-force-delete` |
| `git reset --hard` | deny `core.git:reset-hard` |

## Both conditions are load-bearing

Each alone keeps the deny:

- An **unquoted** delimiter (`<<PY`) is expanded by the outer shell before the receiver ever runs.
- A **shell** receiver (`bash`, `sh`, `zsh`, `fish`, PowerShell) expands the body when it executes it.

`dash` and `ksh` map to `ScriptLanguage::Unknown`, which must never be read as "not a shell". The new predicate therefore requires a *proven* non-shell language (`Python`, `JavaScript`, `TypeScript`, `Ruby`, `Perl`, `Php`, `Go` — the same set `range_intersects_conservatively_scanned_interpreter_input` already enumerates), so `dash`, `ksh`, `jq`, `sqlite3`, and any unrecognized receiver stay conservative.

The predicate reuses the existing receiver-proof machinery (`extract_heredoc_target_command` + `stdin_data_sink_may_be_overridden`), so it fails closed on everything the data-sink masking already fails closed on:

| shape | still denies |
|---|---|
| `env` / `sudo` / `command` / `builtin` / `nohup` wrapper | yes |
| `python3() { bash -s; }` before the heredoc | yes |
| `alias python3='bash -s'` | yes |
| `eval 'python3(){ bash -s; }'` / `source ./bindings.sh` | yes |
| `./python3`, `/tmp/python3` (arbitrary path) | yes |
| `git branch $name` **after** the terminator | yes |
| `echo 'python3 - <<PY'` (heredoc-looking text in quotes) | yes |
| here-string, unparsable command, range straddling the body | yes |

## No new false-negative class

The one shape a reviewer will reach for is a body that shells out:

```
python3 - <<'PY'
os.system("git branch $name")
PY
```

That is **already allowed on current `main`** — via the same quoting logic that allows the `python3 -c` spelling. This change makes the two spellings agree; it does not open a door that was shut. I checked before writing the patch rather than after.

## Verification

Against the reporter's 33-case corpus (stock `main` @ `d1ada2d` vs this branch):

| group | main | this branch |
|---|---|---|
| FP — must allow | 6/16 | **8/16** |
| PROTECTION — must deny | 10/10 | **10/10** |
| SAFE — documented safe spellings | 3/3 | **3/3** |
| KNOWN-FN | 0/4 | 0/4 |

Both newly-passing FP cases are the heredoc-delivered ones. The eight still failing and the four known bypasses are the separate glob-basename defect (#360/#361), addressed in #364.

The two changes are independent and compose. Merged together they give **FP 15/16, PROTECTION 10/10, SAFE 3/3, KNOWN-FN 4/4** (the one remaining FP is `/* -D x`, denied by design per #364). They touch disjoint source files; the only merge conflict is a trivial append at the end of `tests/corpus/bypass_attempts/obfuscation.toml`, where both blocks are kept. Either can land first.

One protection case changes its *attribution* while staying denied: `heredoc-then-force-delete` now reports `core.git:branch-force-delete` instead of `core.git:branch-dynamic-token`, because the real `git branch -D feature` after the terminator is now what carries the finding rather than text inside the body. That is the more accurate rule.

Gates: `cargo test --release` 4324 tests, 0 failures. `cargo fmt --check` and `cargo clippy --all-targets` clean.

## Tests

- `src/heredoc.rs` — four unit tests over the new predicate: modeled non-shell interpreters are inert; expanding delimiters and shell receivers never are; wrapper/rebindable/path receivers never are; only the body's own bytes are claimed, with empty, inverted, straddling, and fake-operator ranges rejected.
- `src/evaluator.rs` — four end-to-end tests at the evaluator seam, run in both `Posix` and `Unknown` dialects, covering the allow set, the shell/unquoted deny set, the literal-evidence-survives set, and the wrapper/rebind set.
- `tests/corpus/false_positives/heredoc_data.toml` — 4 cases.
- `tests/corpus/true_positives/git_destructive.toml` — 4 cases (unquoted delimiter, shell receiver, unmodeled receiver, literal deletion in a quoted interpreter body).
- `tests/corpus/bypass_attempts/obfuscation.toml` — 3 cases (wrapper, rebound name, after the terminator).

## One conservative remainder, left in place

Unrelated to this rule: `extract_heredoc_target_resolution` treats a dotted name as a filename argument, so `python3.11 - <<'PY'` resolves to no target and keeps the deny. That fails closed, which is the right direction; widening target resolution is a separate change. A test documents the current behavior so it is not mistaken for part of this fix.

---

By Merlin ([rbeckner.com](https://rbeckner.com)) and his AI agent (Claude Code, Fable 5, thinking on: default).
